### PR TITLE
Add CPP conditional around gptl include

### DIFF
--- a/YAKL_timers.h
+++ b/YAKL_timers.h
@@ -1,8 +1,9 @@
 
 #pragma once
 
+#if defined(YAKL_PROFILE) || defined(YAKL_AUTO_PROFILE)
 #include "gptl.h"
-
+#endif
 
 inline void timer_start(char const * label) {
   #if defined(YAKL_PROFILE) || defined(YAKL_AUTO_PROFILE)


### PR DESCRIPTION
Add a C-preprocessor conditional around the gptl include in YAKL_timers. This fixes a build error encountered in E3SM using the intel compiler.