### PR TITLE
Make sure CXX, C, and Fortran are enabled for project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+project(YAKL C CXX Fortran)
 
 set(YAKL_C_SOURCE gptl/GPTLget_memusage.c gptl/GPTLprint_memusage.c gptl/GPTLutil.c gptl/gptl.c gptl/gptl_papi.c)
 set(YAKL_CXX_SOURCE YAKL.cpp)


### PR DESCRIPTION
Required for using in other projects that explicitly list enabled languages via a `project` line.