### PR TITLE
[SYCL] kernel launches, atomic reductions

### DIFF
--- a/YAKL.h
+++ b/YAKL.h
@@ -70,7 +70,7 @@ namespace yakl {
     inline void yaklFreeHost( void *ptr , char const *label ) { yaklFreeHostFunc(ptr,label); }
     inline void yakl_mtx_lock()   { yakl_mtx.lock(); }
     inline void yakl_mtx_unlock() { yakl_mtx.unlock(); }
-  #endif
+ #endif
 
 
   // Block the CPU code until the device code and data transfers are all completed
@@ -105,6 +105,11 @@ namespace yakl {
       cudaFree(functorBuffer);
       check_last_error();
     #endif
+    #if defined(YAKL_ARCH_SYCL)
+      sycl::free(functorBuffer, sycl_default_stream);
+      check_last_error();
+    #endif
+
     yakl_is_initialized = false;
     size_t hwm = pool.highWaterMark();
     if        (hwm >= 1024*1024*1024) {
@@ -115,10 +120,6 @@ namespace yakl {
       if (yakl_masterproc()) std::cout << "Memory high water mark: " << (double) hwm / (double) (1024          ) << " KB\n";
     }
     pool.finalize();
-    #if defined(YAKL_ARCH_SYCL)
-      sycl::free(functorBuffer, sycl_default_stream);
-      check_last_error();
-    #endif
     #if defined(YAKL_PROFILE) || defined(YAKL_AUTO_PROFILE)
       GPTLpr_file("");
       GPTLpr_file("yakl_timer_output.txt");

--- a/YAKL_Gator.h
+++ b/YAKL_Gator.h
@@ -9,7 +9,6 @@
 #endif
 #if defined(YAKL_ARCH_SYCL)
   #include <CL/sycl.hpp>
-  namespace sycl = cl::sycl;
 #endif
 #if defined( YAKL_ARCH_OPENMP45)
   #include <omp.h>

--- a/YAKL_Intrinsics.h
+++ b/YAKL_Intrinsics.h
@@ -250,49 +250,49 @@ namespace intrinsics {
   // any* device Array
   ///////////////////////////
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyLT ( Array<T,rank,yakl::memDevice,myStyle> const &arr , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyLT ( Array<T,rank,memDevice,myStyle> const &arr , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( arr.myData[i] < val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyLTE ( Array<T,rank,yakl::memDevice,myStyle> const &arr , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyLTE ( Array<T,rank,memDevice,myStyle> const &arr , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( arr.myData[i] <= val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyGT ( Array<T,rank,yakl::memDevice,myStyle> const &arr , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyGT ( Array<T,rank,memDevice,myStyle> const &arr , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( arr.myData[i] > val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyGTE ( Array<T,rank,yakl::memDevice,myStyle> const &arr , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyGTE ( Array<T,rank,memDevice,myStyle> const &arr , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( arr.myData[i] >= val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyEQ ( Array<T,rank,yakl::memDevice,myStyle> const &arr , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyEQ ( Array<T,rank,memDevice,myStyle> const &arr , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( arr.myData[i] == val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyNEQ ( Array<T,rank,yakl::memDevice,myStyle> const &arr , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyNEQ ( Array<T,rank,memDevice,myStyle> const &arr , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( arr.myData[i] != val ) { ret = true; }
     });
     return ret.hostRead();
@@ -303,49 +303,49 @@ namespace intrinsics {
   // any* device Array Masked
   ///////////////////////////
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyLT ( Array<T,rank,yakl::memDevice,myStyle> const &arr , Array<bool,rank,yakl::memDevice,myStyle> const &mask , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyLT ( Array<T,rank,memDevice,myStyle> const &arr , Array<bool,rank,memDevice,myStyle> const &mask , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( mask.myData[i] && arr.myData[i] < val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyLTE ( Array<T,rank,yakl::memDevice,myStyle> const &arr , Array<bool,rank,yakl::memDevice,myStyle> const &mask , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyLTE ( Array<T,rank,memDevice,myStyle> const &arr , Array<bool,rank,memDevice,myStyle> const &mask , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( mask.myData[i] && arr.myData[i] <= val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyGT ( Array<T,rank,yakl::memDevice,myStyle> const &arr , Array<bool,rank,yakl::memDevice,myStyle> const &mask , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyGT ( Array<T,rank,memDevice,myStyle> const &arr , Array<bool,rank,memDevice,myStyle> const &mask , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( mask.myData[i] && arr.myData[i] > val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyGTE ( Array<T,rank,yakl::memDevice,myStyle> const &arr , Array<bool,rank,yakl::memDevice,myStyle> const &mask , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyGTE ( Array<T,rank,memDevice,myStyle> const &arr , Array<bool,rank,memDevice,myStyle> const &mask , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( mask.myData[i] && arr.myData[i] >= val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyEQ ( Array<T,rank,yakl::memDevice,myStyle> const &arr , Array<bool,rank,yakl::memDevice,myStyle> const &mask , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyEQ ( Array<T,rank,memDevice,myStyle> const &arr , Array<bool,rank,memDevice,myStyle> const &mask , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( mask.myData[i] && arr.myData[i] == val ) { ret = true; }
     });
     return ret.hostRead();
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyNEQ ( Array<T,rank,yakl::memDevice,myStyle> const &arr , Array<bool,rank,yakl::memDevice,myStyle> const &mask , TVAL val ) {
-    yakl::ScalarLiveOut<bool> ret(false);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
+  inline bool anyNEQ ( Array<T,rank,memDevice,myStyle> const &arr , Array<bool,rank,memDevice,myStyle> const &mask , TVAL val ) {
+    ScalarLiveOut<bool> ret(false);
+    c::parallel_for( c::SimpleBounds<1>(arr.totElems()) , YAKL_LAMBDA (int i) {
       if ( mask.myData[i] && arr.myData[i] != val ) { ret = true; }
     });
     return ret.hostRead();
@@ -357,7 +357,7 @@ namespace intrinsics {
   // any* host Array
   ///////////////////////////
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyLT( Array<T,rank,yakl::memHost,myStyle> const &arr , TVAL val ) {
+  inline bool anyLT( Array<T,rank,memHost,myStyle> const &arr , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( arr.myData[i] < val ) { ret = true; }
@@ -365,7 +365,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyLTE( Array<T,rank,yakl::memHost,myStyle> const &arr , TVAL val ) {
+  inline bool anyLTE( Array<T,rank,memHost,myStyle> const &arr , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( arr.myData[i] <= val ) { ret = true; }
@@ -373,7 +373,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyGT( Array<T,rank,yakl::memHost,myStyle> const &arr , TVAL val ) {
+  inline bool anyGT( Array<T,rank,memHost,myStyle> const &arr , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( arr.myData[i] > val ) { ret = true; }
@@ -381,7 +381,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyGTE( Array<T,rank,yakl::memHost,myStyle> const &arr , TVAL val ) {
+  inline bool anyGTE( Array<T,rank,memHost,myStyle> const &arr , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( arr.myData[i] >= val ) { ret = true; }
@@ -389,7 +389,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyEQ( Array<T,rank,yakl::memHost,myStyle> const &arr , TVAL val ) {
+  inline bool anyEQ( Array<T,rank,memHost,myStyle> const &arr , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( arr.myData[i] == val ) { ret = true; }
@@ -397,7 +397,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyNEQ( Array<T,rank,yakl::memHost,myStyle> const &arr , TVAL val ) {
+  inline bool anyNEQ( Array<T,rank,memHost,myStyle> const &arr , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( arr.myData[i] != val ) { ret = true; }
@@ -411,7 +411,7 @@ namespace intrinsics {
   // any* host Array Masked
   ///////////////////////////
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyLT( Array<T,rank,yakl::memHost,myStyle> const &arr , Array<bool,rank,yakl::memHost,myStyle> const &mask , TVAL val ) {
+  inline bool anyLT( Array<T,rank,memHost,myStyle> const &arr , Array<bool,rank,memHost,myStyle> const &mask , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( mask.myData[i] && arr.myData[i] < val ) { ret = true; }
@@ -419,7 +419,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyLTE( Array<T,rank,yakl::memHost,myStyle> const &arr , Array<bool,rank,yakl::memHost,myStyle> const &mask , TVAL val ) {
+  inline bool anyLTE( Array<T,rank,memHost,myStyle> const &arr , Array<bool,rank,memHost,myStyle> const &mask , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( mask.myData[i] && arr.myData[i] <= val ) { ret = true; }
@@ -427,7 +427,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyGT( Array<T,rank,yakl::memHost,myStyle> const &arr , Array<bool,rank,yakl::memHost,myStyle> const &mask , TVAL val ) {
+  inline bool anyGT( Array<T,rank,memHost,myStyle> const &arr , Array<bool,rank,memHost,myStyle> const &mask , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( mask.myData[i] && arr.myData[i] > val ) { ret = true; }
@@ -435,7 +435,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyGTE( Array<T,rank,yakl::memHost,myStyle> const &arr , Array<bool,rank,yakl::memHost,myStyle> const &mask , TVAL val ) {
+  inline bool anyGTE( Array<T,rank,memHost,myStyle> const &arr , Array<bool,rank,memHost,myStyle> const &mask , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( mask.myData[i] && arr.myData[i] >= val ) { ret = true; }
@@ -443,7 +443,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyEQ( Array<T,rank,yakl::memHost,myStyle> const &arr , Array<bool,rank,yakl::memHost,myStyle> const &mask , TVAL val ) {
+  inline bool anyEQ( Array<T,rank,memHost,myStyle> const &arr , Array<bool,rank,memHost,myStyle> const &mask , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( mask.myData[i] && arr.myData[i] == val ) { ret = true; }
@@ -451,7 +451,7 @@ namespace intrinsics {
     return ret;
   }
   template <class T, class TVAL, int rank, int myStyle>
-  inline bool anyNEQ( Array<T,rank,yakl::memHost,myStyle> const &arr , Array<bool,rank,yakl::memHost,myStyle> const &mask , TVAL val ) {
+  inline bool anyNEQ( Array<T,rank,memHost,myStyle> const &arr , Array<bool,rank,memHost,myStyle> const &mask , TVAL val ) {
     bool ret = false;
     for (int i=0; i < arr.totElems(); i++) {
       if ( mask.myData[i] && arr.myData[i] != val ) { ret = true; }
@@ -969,9 +969,9 @@ namespace intrinsics {
   }
   template <int rank, int myStyle>
   inline int count( Array<bool,rank,memDevice,myStyle> const &mask ) {
-    yakl::ScalarLiveOut<int> numTrue(0);
-    yakl::c::parallel_for( yakl::c::SimpleBounds<1>( mask.totElems() ) , YAKL_DEVICE_LAMBDA (int i) {
-      if (mask.myData[i]) { yakl::atomicAdd(numTrue(),1); }
+    ScalarLiveOut<int> numTrue(0);
+    c::parallel_for( c::SimpleBounds<1>( mask.totElems() ) , YAKL_DEVICE_LAMBDA (int i) {
+      if (mask.myData[i]) { atomicAdd(numTrue(),1); }
     });
     return numTrue.hostRead();
   }

--- a/YAKL_alloc_free.h
+++ b/YAKL_alloc_free.h
@@ -75,7 +75,6 @@ namespace yakl {
         alloc = [] ( size_t bytes ) -> void* {
           if (bytes == 0) return nullptr;
           void *ptr = sycl::malloc_shared(bytes,sycl_default_stream);
-          sycl_default_stream.memset(ptr, 0, bytes).wait();
           check_last_error();
           sycl_default_stream.prefetch(ptr,bytes);
           return ptr;
@@ -88,15 +87,12 @@ namespace yakl {
         alloc = [] ( size_t bytes ) -> void* {
           if (bytes == 0) return nullptr;
           void *ptr = sycl::malloc_device(bytes,sycl_default_stream);
-          sycl_default_stream.memset(ptr, 0, bytes).wait();
           check_last_error();
           return ptr;
         };
         dealloc = [] ( void *ptr ) {
-          sycl_default_stream.wait();
           sycl::free(ptr, sycl_default_stream);
           check_last_error();
-          ptr = nullptr;
         };
       #endif
     #elif defined(YAKL_ARCH_OPENMP45)

--- a/YAKL_alloc_free.h
+++ b/YAKL_alloc_free.h
@@ -75,31 +75,27 @@ namespace yakl {
         alloc = [] ( size_t bytes ) -> void* {
           if (bytes == 0) return nullptr;
           void *ptr = sycl::malloc_shared(bytes,sycl_default_stream);
+          sycl_default_stream.memset(ptr, 0, bytes).wait();
           check_last_error();
           sycl_default_stream.prefetch(ptr,bytes);
           return ptr;
         };
         dealloc = [] ( void *ptr ) {
-          sycl::free(ptr, sycl_default_stream).wait();
+          sycl::free(ptr, sycl_default_stream);
           check_last_error();
         };
       #else
         alloc = [] ( size_t bytes ) -> void* {
           if (bytes == 0) return nullptr;
           void *ptr = sycl::malloc_device(bytes,sycl_default_stream);
-          std::cout << "ALLOC: " << ptr << "\n";
+          sycl_default_stream.memset(ptr, 0, bytes).wait();
           check_last_error();
           return ptr;
         };
         dealloc = [] ( void *ptr ) {
-          std::cout << "FREE: " << ptr << "\n";
-          std::cout << "Running on "
-                    << sycl_default_stream.get_device().get_info<sycl::info::device::name>()
-                    << "\n";
-          sycl_default_stream.wait();
           sycl::free(ptr, sycl_default_stream);
-          sycl_default_stream.wait();
           check_last_error();
+          ptr = nullptr;
         };
       #endif
     #elif defined(YAKL_ARCH_OPENMP45)

--- a/YAKL_atomics.h
+++ b/YAKL_atomics.h
@@ -112,9 +112,9 @@
   template <typename T, sycl::access::address_space addressSpace =
       sycl::access::address_space::global_space>
   using relaxed_atomic_ref =
-sycl::ONEAPI::atomic_ref< T,
-        sycl::ONEAPI::memory_order::relaxed,
-        sycl::ONEAPI::memory_scope::device,
+sycl::ext::oneapi::atomic_ref< T,
+        sycl::ext::oneapi::memory_order::relaxed,
+        sycl::ext::oneapi::memory_scope::device,
         addressSpace>;
 
 
@@ -141,11 +141,11 @@ sycl::ONEAPI::atomic_ref< T,
     float old_float_value;
 
     do {
-      old_value = obj.load(sycl::ONEAPI::memory_order::relaxed);
+      old_value = obj.load(sycl::memory_order::relaxed);
       old_float_value = *reinterpret_cast<const float *>(&old_value);
       const float new_float_value = old_float_value + operand;
       const int new_value = *reinterpret_cast<const int *>(&new_float_value);
-      if (obj.compare_exchange_strong(old_value, new_value, sycl::ONEAPI::memory_order::relaxed))
+      if (obj.compare_exchange_strong(old_value, new_value, sycl::memory_order::relaxed))
         break;
     } while (true);
 
@@ -166,13 +166,13 @@ sycl::ONEAPI::atomic_ref< T,
     double old_double_value;
 
     do {
-      old_value = obj.load(sycl::ONEAPI::memory_order::relaxed);
+      old_value = obj.load(sycl::memory_order::relaxed);
       old_double_value = *reinterpret_cast<const double *>(&old_value);
       const double new_double_value = old_double_value + operand;
       const unsigned long long int new_value =
         *reinterpret_cast<const unsigned long long int *>(&new_double_value);
 
-      if (obj.compare_exchange_strong(old_value, new_value, sycl::ONEAPI::memory_order::relaxed))
+      if (obj.compare_exchange_strong(old_value, new_value, sycl::memory_order::relaxed))
         break;
     } while (true);
 

--- a/YAKL_defines.h
+++ b/YAKL_defines.h
@@ -32,7 +32,7 @@
   #define YAKL_DEVICE_INLINE __inline__ __attribute__((always_inline))
   #define YAKL_SCOPE(a,b) auto &a = std::ref(b).get()
   #define YAKL_SEPARATE_MEMORY_SPACE
-  #define YAKL_CURRENTLY_ON_HOST() 1
+  #define YAKL_CURRENTLY_ON_HOST() (! defined(__SYCL_DEVICE_ONLY__))
   #include <CL/sycl.hpp>
 
 #elif defined(YAKL_ARCH_OPENMP45)

--- a/YAKL_defines.h
+++ b/YAKL_defines.h
@@ -31,7 +31,6 @@
   #define YAKL_SCOPE(a,b) auto &a = std::ref(b).get()
   #define YAKL_SEPARATE_MEMORY_SPACE
   #include <CL/sycl.hpp>
-  namespace sycl = cl::sycl;
 
 #elif defined(YAKL_ARCH_OPENMP45)
 

--- a/YAKL_fft.h
+++ b/YAKL_fft.h
@@ -57,10 +57,10 @@ Example usage:
     pressure(k,j,i) = ...;
   });
 
-  yakl::RealFFT1D<n,double> fft_x;
+  RealFFT1D<n,double> fft_x;
   fft_x.init(fft_x.trig);
 
-  yakl::RealFFT1D<n,double> fft_y;
+  RealFFT1D<n,double> fft_y;
   fft_y.init(fft_y.trig);
 
   // x-direction forward FFTs
@@ -69,7 +69,7 @@ Example usage:
     for (int i=0; i < nx; i++) {
       data(i) = pressure(k,j,i);
     }
-    fft_x.forward(data,fft_x.trig,yakl::FFT_SCALE_ECMWF);
+    fft_x.forward(data,fft_x.trig,FFT_SCALE_ECMWF);
     for (int i=0; i < nx+2; i++) {
       pressure(k,j,i) = data(i);
     }
@@ -81,7 +81,7 @@ Example usage:
     for (int j=0; j < ny; j++) {
       data(j) = pressure(k,j,i);
     }
-    fft_y.forward(data,fft_y.trig,yakl::FFT_SCALE_ECMWF);
+    fft_y.forward(data,fft_y.trig,FFT_SCALE_ECMWF);
     for (int j=0; j < ny+2; j++) {
       pressure(k,j,i) = data(j);
     }
@@ -95,7 +95,7 @@ Example usage:
     for (int j=0; j < ny+2; j++) {
       data(j) = pressure(k,j,i);
     }
-    fft_y.inverse(data,fft_y.trig,yakl::FFT_SCALE_ECMWF);
+    fft_y.inverse(data,fft_y.trig,FFT_SCALE_ECMWF);
     for (int j=0; j < ny; j++) {
       pressure(k,j,i) = data(j);
     }
@@ -107,7 +107,7 @@ Example usage:
     for (int i=0; i < nx+2; i++) {
       data(i) = pressure(k,j,i);
     }
-    fft_x.inverse(data,fft_x.trig,yakl::FFT_SCALE_ECMWF);
+    fft_x.inverse(data,fft_x.trig,FFT_SCALE_ECMWF);
     for (int i=0; i < nx; i++) {
       pressure(k,j,i) = data(i);
     }
@@ -128,7 +128,7 @@ namespace yakl {
 
   template <unsigned int SIZE, class real = double>
   class RealFFT1D {
-    typedef yakl::Array<real,1,yakl::memDevice,yakl::styleC> real1d;
+    typedef Array<real,1,memDevice,styleC> real1d;
 
     public:
 
@@ -151,13 +151,13 @@ namespace yakl {
 
     inline void init(real1d &trig) {
       int constexpr log2_no2 = mylog2<SIZE/2>::value;
-      yakl::c::parallel_for( log2_no2 , YAKL_LAMBDA (int i) {
+      c::parallel_for( log2_no2 , YAKL_LAMBDA (int i) {
         unsigned int m = 1;
         for (int j=1; j <= i+1; j++) { m *= 2; }
         trig(OFF_COS1+i) = cos(2*M_PI/static_cast<real>(m));
         trig(OFF_SIN1+i) = sin(2*M_PI/static_cast<real>(m));
       });
-      yakl::c::parallel_for( SIZE/2 , YAKL_LAMBDA (int i) {
+      c::parallel_for( SIZE/2 , YAKL_LAMBDA (int i) {
         trig(OFF_COS2+i) = cos(2*M_PI*i/static_cast<real>(SIZE));
         trig(OFF_SIN2+i) = sin(2*M_PI*i/static_cast<real>(SIZE));
       });
@@ -166,7 +166,7 @@ namespace yakl {
 
     template <class ARR>
     YAKL_INLINE void forward(ARR &data, real1d const &trig, int scale = FFT_SCALE_STANDARD) const {
-      yakl::SArray<real,1,SIZE> tmp;
+      SArray<real,1,SIZE> tmp;
       int constexpr n = SIZE;
       bit_reverse_copy_real_forward(data,tmp);
       fft_post_bit_reverse(tmp,trig);
@@ -196,7 +196,7 @@ namespace yakl {
 
     template <class ARR>
     YAKL_INLINE void inverse(ARR &data, real1d const &trig, int scale = FFT_SCALE_STANDARD) const {
-      yakl::SArray<real,1,SIZE> tmp;
+      SArray<real,1,SIZE> tmp;
       int constexpr  n = SIZE;
       bit_reverse_copy_real_inverse(data,tmp,trig);
       fft_post_bit_reverse(tmp,trig);

--- a/YAKL_init.h
+++ b/YAKL_init.h
@@ -166,7 +166,7 @@ namespace yakl {
           void *ptr = sycl::malloc_shared(bytes,sycl_default_stream);
           sycl_default_stream.memset(ptr, 0, bytes).wait();
           check_last_error();
-          sycl_default_stream.prefetch(ptr,bytes);
+          sycl_default_stream.prefetch(ptr,bytes).wait();
           return ptr;
         };
         dealloc = [] ( void *ptr ) {

--- a/YAKL_init.h
+++ b/YAKL_init.h
@@ -24,8 +24,7 @@
         }
       };
 
-      sycl::default_selector device_selector;
-      sycl_default_stream = sycl::queue(device_selector, asyncHandler,
+      sycl_default_stream = sycl::queue(sycl::gpu_selector{}, asyncHandler,
                                         sycl::property_list{sycl::property::queue::in_order{}});
       std::cout << "Running on "
                 << sycl_default_stream.get_device().get_info<sycl::info::device::name>()
@@ -68,9 +67,11 @@
 
     yaklAllocHostFunc = [] (size_t bytes , char const *label) -> void * { return malloc(bytes); };
     yaklFreeHostFunc  = [] (void *ptr , char const *label) { free(ptr); };
-
-    #ifdef YAKL_ARCH_CUDA
+    #if defined(YAKL_ARCH_CUDA)
       cudaMalloc(&functorBuffer,functorBufSize);
+    #elif defined(YAKL_ARCH_SYCL)
+      functorBuffer = sycl::malloc_device(functorBufSize, sycl_default_stream);
+      sycl_default_stream.memset(functorBuffer, 0, functorBufSize).wait();
     #endif
 
     #if defined(YAKL_ARCH_HIP)
@@ -86,3 +87,129 @@
     #endif
 
   } //
+
+#pragma once
+
+#include "YAKL_error.h"
+
+namespace yakl {
+
+#ifdef YAKL_ARCH_SYCL
+  extern sycl::queue sycl_default_stream;
+#endif
+
+  inline void set_alloc_free(std::function<void *( size_t )> &alloc , std::function<void ( void * )> &dealloc) {
+    #if   defined(YAKL_ARCH_CUDA)
+      #if defined (YAKL_MANAGED_MEMORY)
+        alloc   = [] ( size_t bytes ) -> void* {
+          if (bytes == 0) return nullptr;
+          void *ptr;
+          cudaMallocManaged(&ptr,bytes);
+          check_last_error();
+          cudaMemPrefetchAsync(ptr,bytes,0);
+          check_last_error();
+          #ifdef _OPENMP45
+            omp_target_associate_ptr(ptr,ptr,bytes,0,0);
+          #endif
+          #ifdef _OPENACC
+            acc_map_data(ptr,ptr,bytes);
+          #endif
+          return ptr;
+        };
+        dealloc = [] ( void *ptr    ) {
+          cudaFree(ptr);
+          check_last_error();
+        };
+      #else
+        alloc   = [] ( size_t bytes ) -> void* {
+          if (bytes == 0) return nullptr;
+          void *ptr;
+          cudaMalloc(&ptr,bytes);
+          check_last_error();
+          return ptr;
+        };
+        dealloc = [] ( void *ptr    ) {
+          cudaFree(ptr);
+          check_last_error();
+        };
+      #endif
+    #elif defined(YAKL_ARCH_HIP)
+      #if defined (YAKL_MANAGED_MEMORY)
+        alloc = [] ( size_t bytes ) -> void* {
+          if (bytes == 0) return nullptr;
+          void *ptr;
+          hipMallocHost(&ptr,bytes);
+          check_last_error();
+          return ptr;
+        };
+        dealloc = [] ( void *ptr    ) {
+          hipFree(ptr);
+          check_last_error();
+        };
+      #else
+        alloc = [] ( size_t bytes ) -> void* {
+          if (bytes == 0) return nullptr;
+          void *ptr;
+          hipMalloc(&ptr,bytes);
+          check_last_error();
+          return ptr;
+        };
+        dealloc = [] ( void *ptr ) {
+          hipFree(ptr);
+          check_last_error();
+        };
+      #endif
+    #elif defined (YAKL_ARCH_SYCL)
+      #if defined (YAKL_MANAGED_MEMORY)
+        alloc = [] ( size_t bytes ) -> void* {
+          if (bytes == 0) return nullptr;
+          void *ptr = sycl::malloc_shared(bytes,sycl_default_stream);
+          sycl_default_stream.memset(ptr, 0, bytes).wait();
+          check_last_error();
+          sycl_default_stream.prefetch(ptr,bytes);
+          return ptr;
+        };
+        dealloc = [] ( void *ptr ) {
+          sycl::free(ptr, sycl_default_stream);
+          check_last_error();
+        };
+      #else
+        alloc = [] ( size_t bytes ) -> void* {
+          if (bytes == 0) return nullptr;
+          void *ptr = sycl::malloc_device(bytes,sycl_default_stream);
+          sycl_default_stream.memset(ptr, 0, bytes).wait();
+          check_last_error();
+          return ptr;
+        };
+        dealloc = [] ( void *ptr ) {
+          sycl::free(ptr, sycl_default_stream);
+          check_last_error();
+          ptr = nullptr;
+        };
+      #endif
+    #elif defined(YAKL_ARCH_OPENMP45)
+      alloc = [] ( size_t bytes ) -> void* {
+        if (bytes == 0) return nullptr;
+        void *ptr;
+        int device;
+        device = omp_get_default_device();
+        ptr = omp_target_alloc(bytes,device);
+        //check does nothing
+        check_last_error();
+        return ptr;
+      };
+      dealloc = [] (void *ptr) {
+        int device;
+        device = omp_get_default_device();
+        omp_target_free(ptr,device);
+        //check does nothing
+        check_last_error();
+      };
+    #else
+      alloc   = [] ( size_t bytes ) -> void* { if (bytes == 0) return nullptr; return ::malloc(bytes); };
+      dealloc = [] ( void *ptr ) { ::free(ptr); };
+    #endif
+  }
+
+}
+

--- a/YAKL_init.h
+++ b/YAKL_init.h
@@ -79,7 +79,6 @@
       #endif
       #ifdef YAKL_ARCH_SYCL
         functorBuffer = sycl::malloc_device(functorBufSize, sycl_default_stream);
-        sycl_default_stream.memset(functorBuffer, 0, functorBufSize).wait();
       #endif
 
       #if defined(YAKL_ARCH_HIP)
@@ -176,9 +175,8 @@ namespace yakl {
         alloc = [] ( size_t bytes ) -> void* {
           if (bytes == 0) return nullptr;
           void *ptr = sycl::malloc_shared(bytes,sycl_default_stream);
-          sycl_default_stream.memset(ptr, 0, bytes).wait();
           check_last_error();
-          sycl_default_stream.prefetch(ptr,bytes).wait();
+          sycl_default_stream.prefetch(ptr,bytes);
           return ptr;
         };
         dealloc = [] ( void *ptr ) {
@@ -189,14 +187,12 @@ namespace yakl {
         alloc = [] ( size_t bytes ) -> void* {
           if (bytes == 0) return nullptr;
           void *ptr = sycl::malloc_device(bytes,sycl_default_stream);
-          sycl_default_stream.memset(ptr, 0, bytes).wait();
           check_last_error();
           return ptr;
         };
         dealloc = [] ( void *ptr ) {
           sycl::free(ptr, sycl_default_stream);
           check_last_error();
-          ptr = nullptr;
         };
       #endif
     #elif defined(YAKL_ARCH_OPENMP45)

--- a/YAKL_mem_transfers.h
+++ b/YAKL_mem_transfers.h
@@ -16,7 +16,7 @@
       hipMemcpyAsync(dst,src,elems*sizeof(T),hipMemcpyDeviceToHost,0);
       check_last_error();
     #elif defined (YAKL_ARCH_SYCL)
-      sycl_default_stream.memcpy(dst, src, elems*sizeof(T)).wait();
+      sycl_default_stream.memcpy(dst, src, elems*sizeof(T));
       check_last_error();
     #elif defined(YAKL_ARCH_OPENMP45)
       omp_target_memcpy(dst,src,elems*sizeof(T),0,0,omp_get_initial_device(),omp_get_default_device());
@@ -42,7 +42,7 @@
       hipMemcpyAsync(dst,src,elems*sizeof(T),hipMemcpyHostToDevice,0);
       check_last_error();
     #elif defined (YAKL_ARCH_SYCL)
-      sycl_default_stream.memcpy(dst, src, elems*sizeof(T)).wait();
+      sycl_default_stream.memcpy(dst, src, elems*sizeof(T));
       check_last_error();
     #elif defined(YAKL_ARCH_OPENMP45)
       omp_target_memcpy(dst,src,elems*sizeof(T),0,0,omp_get_default_device(),omp_get_initial_device());
@@ -68,7 +68,7 @@
       hipMemcpyAsync(dst,src,elems*sizeof(T),hipMemcpyDeviceToDevice,0);
       check_last_error();
     #elif defined (YAKL_ARCH_SYCL)
-      sycl_default_stream.memcpy(dst, src, elems*sizeof(T)).wait();
+      sycl_default_stream.memcpy(dst, src, elems*sizeof(T));
       check_last_error();
     #elif defined(YAKL_ARCH_OPENMP45)
       omp_target_memcpy(dst,src,elems*sizeof(T),0,0,omp_get_default_device(),omp_get_default_device());

--- a/YAKL_mem_transfers.h
+++ b/YAKL_mem_transfers.h
@@ -16,7 +16,7 @@
       hipMemcpyAsync(dst,src,elems*sizeof(T),hipMemcpyDeviceToHost,0);
       check_last_error();
     #elif defined (YAKL_ARCH_SYCL)
-      sycl_default_stream.memcpy(dst, src, elems*sizeof(T));
+      sycl_default_stream.memcpy(dst, src, elems*sizeof(T)).wait();
       check_last_error();
     #elif defined(YAKL_ARCH_OPENMP45)
       omp_target_memcpy(dst,src,elems*sizeof(T),0,0,omp_get_initial_device(),omp_get_default_device());
@@ -42,7 +42,7 @@
       hipMemcpyAsync(dst,src,elems*sizeof(T),hipMemcpyHostToDevice,0);
       check_last_error();
     #elif defined (YAKL_ARCH_SYCL)
-      sycl_default_stream.memcpy(dst, src, elems*sizeof(T));
+      sycl_default_stream.memcpy(dst, src, elems*sizeof(T)).wait();
       check_last_error();
     #elif defined(YAKL_ARCH_OPENMP45)
       omp_target_memcpy(dst,src,elems*sizeof(T),0,0,omp_get_default_device(),omp_get_initial_device());
@@ -68,7 +68,7 @@
       hipMemcpyAsync(dst,src,elems*sizeof(T),hipMemcpyDeviceToDevice,0);
       check_last_error();
     #elif defined (YAKL_ARCH_SYCL)
-      sycl_default_stream.memcpy(dst, src, elems*sizeof(T));
+      sycl_default_stream.memcpy(dst, src, elems*sizeof(T)).wait();
       check_last_error();
     #elif defined(YAKL_ARCH_OPENMP45)
       omp_target_memcpy(dst,src,elems*sizeof(T),0,0,omp_get_default_device(),omp_get_default_device());

--- a/YAKL_parallel_for_c.h
+++ b/YAKL_parallel_for_c.h
@@ -594,17 +594,17 @@ namespace c {
 
   #ifdef YAKL_ARCH_SYCL
     template<class F, int N, bool simple>
-    void parallel_for_sycl( Bounds<N,simple> const &bounds , F const &f , int vectorSize = 128 ) {
+    void parallel_for_sycl( Bounds<N,simple> const &bounds , F const &f , int vectorSize ) {
       if constexpr (sycl::is_device_copyable<F>::value) {
           sycl_default_stream.parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
               callFunctor( f , bounds , i );
-            }).wait();
+            });
         } else {
         F *fp = (F *) functorBuffer;
-        sycl_default_stream.memcpy(fp, &f, sizeof(F)).wait();
+        sycl_default_stream.memcpy(fp, &f, sizeof(F));
         sycl_default_stream.parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
             callFunctor( *fp , bounds , i );
-          }).wait();
+          });
       }
       check_last_error();
     }

--- a/YAKL_parallel_for_c.h
+++ b/YAKL_parallel_for_c.h
@@ -594,12 +594,18 @@ namespace c {
 
   #ifdef YAKL_ARCH_SYCL
     template<class F, int N, bool simple>
-    void parallel_for_sycl( Bounds<N,simple> const &bounds , F const &f , int vectorSize ) {
-      isTriviallyCopyable<F>();
-
-      sycl_default_stream.parallel_for<class sycl_kernel>( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
-        callFunctor( f , bounds , i );
-      });
+    void parallel_for_sycl( Bounds<N,simple> const &bounds , F const &f , int vectorSize = 128 ) {
+      if constexpr (sycl::is_device_copyable<F>::value) {
+          sycl_default_stream.parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
+              callFunctor( f , bounds , i );
+            }).wait();
+        } else {
+        F *fp = (F *) functorBuffer;
+        sycl_default_stream.memcpy(fp, &f, sizeof(F)).wait();
+        sycl_default_stream.parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
+            callFunctor( *fp , bounds , i );
+          }).wait();
+      }
       check_last_error();
     }
   #endif

--- a/YAKL_parallel_for_fortran.h
+++ b/YAKL_parallel_for_fortran.h
@@ -586,17 +586,17 @@ namespace fortran {
 
   #ifdef YAKL_ARCH_SYCL
     template<class F, int N, bool simple>
-    void parallel_for_sycl( Bounds<N,simple> const &bounds , F const &f , int vectorSize = 128 ) {
+    void parallel_for_sycl( Bounds<N,simple> const &bounds , F const &f , int vectorSize ) {
       if constexpr (sycl::is_device_copyable<F>::value) {
           sycl_default_stream.parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
               callFunctor( f , bounds , i );
-            }).wait();
+            });
         } else {
         F *fp = (F *) functorBuffer;
-        sycl_default_stream.memcpy(fp, &f, sizeof(F)).wait();
+        sycl_default_stream.memcpy(fp, &f, sizeof(F));
         sycl_default_stream.parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
             callFunctor( *fp , bounds , i );
-          }).wait();
+          });
       }
       check_last_error();
     }

--- a/YAKL_parallel_for_fortran.h
+++ b/YAKL_parallel_for_fortran.h
@@ -587,11 +587,17 @@ namespace fortran {
   #ifdef YAKL_ARCH_SYCL
     template<class F, int N, bool simple>
     void parallel_for_sycl( Bounds<N,simple> const &bounds , F const &f , int vectorSize = 128 ) {
-      isTriviallyCopyable<F>();
-
-      sycl_default_stream.parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
-        callFunctor( f , bounds , i );
-      });
+      if constexpr (sycl::is_device_copyable<F>::value) {
+          sycl_default_stream.parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
+              callFunctor( f , bounds , i );
+            }).wait();
+        } else {
+        F *fp = (F *) functorBuffer;
+        sycl_default_stream.memcpy(fp, &f, sizeof(F)).wait();
+        sycl_default_stream.parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
+            callFunctor( *fp , bounds , i );
+          }).wait();
+      }
       check_last_error();
     }
   #endif

--- a/YAKL_reductions.h
+++ b/YAKL_reductions.h
@@ -394,7 +394,6 @@ template <class T, int myMem> class ParallelSum;
     }
     T operator() (T *data) {
       T rslt=0;
-      sycl::nd_range<1> res = get_reduction_range(nItems, rsltP);
       sycl_default_stream.submit([&, nItems = this->nItems](sycl::handler &cgh) {
           cgh.parallel_for(get_reduction_range(nItems, rsltP),
                            sycl::reduction(rsltP, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),

--- a/YAKL_reductions.h
+++ b/YAKL_reductions.h
@@ -368,7 +368,7 @@ template <class T, int myMem> class ParallelSum;
       size_t local_size=0;
       (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
       auto properties = sycl::property::reduction::initialize_to_identity{};
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, 17},
+      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
                                        sycl::reduction(rsltP, std::plus<>(), properties),
                                        [=](sycl::nd_item<1> idx, auto& sum) {
                                          sum.combine(data[idx.get_global_linear_id()]);

--- a/YAKL_reductions.h
+++ b/YAKL_reductions.h
@@ -278,9 +278,12 @@ template <class T, int myMem> class ParallelSum;
       rsltP = nullptr;
     }
     T operator() (T *data) {
-      T rslt;
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, 2},
-                                       sycl::ext::oneapi::reduction(rsltP, sycl::ext::oneapi::minimum<>()),
+      T rslt=0;
+      size_t local_size=0;
+      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
+      auto properties = sycl::property::reduction::initialize_to_identity{};
+      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
+                                       sycl::reduction(rsltP, sycl::minimum<>(), properties),
                                        [=](sycl::nd_item<1> idx, auto& min) {
                                          min.combine(data[idx.get_global_linear_id()]);
                                        }).wait();
@@ -288,8 +291,11 @@ template <class T, int myMem> class ParallelSum;
       return rslt;
     }
     void deviceReduce(T *data, T *devP) {
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, 2},
-                                       sycl::ext::oneapi::reduction(devP, sycl::ext::oneapi::minimum<>()),
+      size_t local_size=0;
+      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
+      auto properties = sycl::property::reduction::initialize_to_identity{};
+      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
+                                       sycl::reduction(devP, sycl::minimum<>(), properties),
                                        [=](sycl::nd_item<1> idx, auto& min) {
                                          min.combine(data[idx.get_global_linear_id()]);
                                        }).wait();
@@ -315,9 +321,12 @@ template <class T, int myMem> class ParallelSum;
       rsltP = nullptr;
     }
     T operator() (T *data) {
-      T rslt;
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, 2},
-                                       sycl::ext::oneapi::reduction(rsltP, sycl::ext::oneapi::maximum<>()),
+      T rslt=0;
+      size_t local_size=0;
+      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
+      auto properties = sycl::property::reduction::initialize_to_identity{};
+      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
+                                       sycl::reduction(rsltP, sycl::maximum<>(), properties),
                                        [=](sycl::nd_item<1> idx, auto& max) {
                                          max.combine(data[idx.get_global_linear_id()]);
                                        }).wait();
@@ -325,8 +334,11 @@ template <class T, int myMem> class ParallelSum;
       return rslt;
     }
     void deviceReduce(T *data, T *devP) {
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, 2},
-                                       sycl::ext::oneapi::reduction(devP, sycl::ext::oneapi::maximum<>()),
+      size_t local_size=0;
+      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
+      auto properties = sycl::property::reduction::initialize_to_identity{};
+      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
+                                       sycl::reduction(devP, sycl::maximum<>(), properties),
                                        [=](sycl::nd_item<1> idx, auto& max) {
                                          max.combine(data[idx.get_global_linear_id()]);
                                        }).wait();
@@ -352,9 +364,12 @@ template <class T, int myMem> class ParallelSum;
       rsltP = nullptr;
     }
     T operator() (T *data) {
-      T rslt;
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, 2},
-                                       sycl::ext::oneapi::reduction(rsltP, sycl::ext::oneapi::plus<>()),
+      T rslt = 0;
+      size_t local_size=0;
+      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
+      auto properties = sycl::property::reduction::initialize_to_identity{};
+      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, 17},
+                                       sycl::reduction(rsltP, std::plus<>(), properties),
                                        [=](sycl::nd_item<1> idx, auto& sum) {
                                          sum.combine(data[idx.get_global_linear_id()]);
                                        }).wait();
@@ -362,8 +377,11 @@ template <class T, int myMem> class ParallelSum;
       return rslt;
     }
     void deviceReduce(T *data, T *devP) {
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, 2},
-                                       sycl::ext::oneapi::reduction(devP, sycl::ext::oneapi::plus<>()),
+      size_t local_size=0;
+      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
+      auto properties = sycl::property::reduction::initialize_to_identity{};
+      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
+                                       sycl::reduction(devP, std::plus<>(), properties),
                                        [=](sycl::nd_item<1> idx, auto& sum) {
                                          sum.combine(data[idx.get_global_linear_id()]);
                                        }).wait();

--- a/YAKL_reductions.h
+++ b/YAKL_reductions.h
@@ -309,8 +309,9 @@ template <class T, int myMem> class ParallelSum;
                                min.combine(data[i]);
                              }
                            });
-        }).wait();
-      sycl_default_stream.memcpy(&rslt,rsltP,sizeof(T)).wait(); // Copy result to host
+        });
+      sycl_default_stream.memcpy(&rslt,rsltP,sizeof(T)); // Copy result to host
+      fence();
       return rslt;
     }
     void deviceReduce(T *data, T *devP) {
@@ -323,7 +324,10 @@ template <class T, int myMem> class ParallelSum;
                                min.combine(data[i]);
                              }
                            });
-        }).wait();
+        });
+      #if defined(YAKL_AUTO_FENCE) || defined(YAKL_DEBUG)
+        fence();
+      #endif
     }
   };
 
@@ -356,8 +360,9 @@ template <class T, int myMem> class ParallelSum;
                                max.combine(data[i]);
                              }
                            });
-        }).wait();
-      sycl_default_stream.memcpy(&rslt,rsltP,sizeof(T)).wait(); // Copy result to host
+        });
+      sycl_default_stream.memcpy(&rslt,rsltP,sizeof(T)); // Copy result to host
+      fence();
       return rslt;
     }
     void deviceReduce(T *data, T *devP) {
@@ -370,7 +375,10 @@ template <class T, int myMem> class ParallelSum;
                                max.combine(data[i]);
                              }
                            });
-        }).wait();
+        });
+      #if defined(YAKL_AUTO_FENCE) || defined(YAKL_DEBUG)
+        fence();
+      #endif
     }
   };
 
@@ -403,9 +411,9 @@ template <class T, int myMem> class ParallelSum;
                                sum.combine(data[i]);
                              }
                            });
-        }).wait();
-
-      sycl_default_stream.memcpy(&rslt,rsltP,sizeof(T)).wait(); // Copy result to host
+        });
+      sycl_default_stream.memcpy(&rslt,rsltP,sizeof(T)); // Copy result to host
+      fence();
       return rslt;
     }
     void deviceReduce(T *data, T *devP) {
@@ -418,7 +426,10 @@ template <class T, int myMem> class ParallelSum;
                                sum.combine(data[i]);
                              }
                            });
-        }).wait();
+        });
+      #if defined(YAKL_AUTO_FENCE) || defined(YAKL_DEBUG)
+        fence();
+      #endif
     }
   };
 

--- a/YAKL_reductions.h
+++ b/YAKL_reductions.h
@@ -258,6 +258,27 @@ template <class T, int myMem> class ParallelSum;
 #elif defined(YAKL_ARCH_SYCL)
 
 
+  static inline size_t get_wg_size_for_reduction(size_t bytes_per_wi) {
+    // The best work-group size depends on implementation details
+    // We make the following assumptions, which aren't specific to DPC++:
+    // - Bigger work-groups are better
+    // - An implementation may reserve 1 element per work-item in shared memory
+    // In practice, DPC++ seems to limit itself to 1/2 of this
+    const size_t max_size = sycl_default_stream.get_device().get_info<sycl::info::device::max_work_group_size>();
+    const size_t local_mem = sycl_default_stream.get_device().get_info<sycl::info::device::local_mem_size>();
+    return std::min(local_mem / bytes_per_wi, max_size) / 2;
+  }
+
+  static inline size_t round_up(size_t N, size_t multiple) { return ((N + multiple - 1) / multiple) * multiple; }
+
+  template <class T>
+  static inline sycl::nd_range<1> get_reduction_range(size_t N, T reductionVars) {
+    size_t bytes_per_wi = sizeof( std::remove_pointer_t<T> );
+    size_t L = get_wg_size_for_reduction(bytes_per_wi);
+    size_t G = round_up(N, L);
+    return sycl::nd_range<1>{G, L};
+  }
+
   template <class T> class ParallelMin<T,memDevice> {
     int    nItems; // Number of items in the array that will be reduced
     T      *rsltP; // Device pointer for reduction result
@@ -279,26 +300,30 @@ template <class T, int myMem> class ParallelSum;
     }
     T operator() (T *data) {
       T rslt=0;
-      size_t local_size=0;
-      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
-      auto properties = sycl::property::reduction::initialize_to_identity{};
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
-                                       sycl::reduction(rsltP, sycl::minimum<>(), properties),
-                                       [=](sycl::nd_item<1> idx, auto& min) {
-                                         min.combine(data[idx.get_global_linear_id()]);
-                                       }).wait();
+      sycl_default_stream.submit([&, nItems = this->nItems](sycl::handler &cgh) {
+          cgh.parallel_for(get_reduction_range(nItems, rsltP),
+                           sycl::reduction(rsltP, sycl::minimum<>(), sycl::property::reduction::initialize_to_identity{}),
+                           [=](sycl::nd_item<1> idx, auto& min) {
+                             const int i = idx.get_global_linear_id();
+                             if (i < nItems) {
+                               min.combine(data[i]);
+                             }
+                           });
+        }).wait();
       sycl_default_stream.memcpy(&rslt,rsltP,sizeof(T)).wait(); // Copy result to host
       return rslt;
     }
     void deviceReduce(T *data, T *devP) {
-      size_t local_size=0;
-      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
-      auto properties = sycl::property::reduction::initialize_to_identity{};
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
-                                       sycl::reduction(devP, sycl::minimum<>(), properties),
-                                       [=](sycl::nd_item<1> idx, auto& min) {
-                                         min.combine(data[idx.get_global_linear_id()]);
-                                       }).wait();
+      sycl_default_stream.submit([&, nItems = this->nItems](sycl::handler &cgh) {
+          cgh.parallel_for(get_reduction_range(nItems, devP),
+                           sycl::reduction(devP, sycl::minimum<>(), sycl::property::reduction::initialize_to_identity{}),
+                           [=](sycl::nd_item<1> idx, auto& min) {
+                             const int i = idx.get_global_linear_id();
+                             if (i < nItems) {
+                               min.combine(data[i]);
+                             }
+                           });
+        }).wait();
     }
   };
 
@@ -322,26 +347,30 @@ template <class T, int myMem> class ParallelSum;
     }
     T operator() (T *data) {
       T rslt=0;
-      size_t local_size=0;
-      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
-      auto properties = sycl::property::reduction::initialize_to_identity{};
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
-                                       sycl::reduction(rsltP, sycl::maximum<>(), properties),
-                                       [=](sycl::nd_item<1> idx, auto& max) {
-                                         max.combine(data[idx.get_global_linear_id()]);
-                                       }).wait();
+      sycl_default_stream.submit([&, nItems = this->nItems](sycl::handler &cgh) {
+          cgh.parallel_for(get_reduction_range(nItems, rsltP),
+                           sycl::reduction(rsltP, sycl::maximum<>(), sycl::property::reduction::initialize_to_identity{}),
+                           [=](sycl::nd_item<1> idx, auto& max) {
+                             const int i = idx.get_global_linear_id();
+                             if (i < nItems) {
+                               max.combine(data[i]);
+                             }
+                           });
+        }).wait();
       sycl_default_stream.memcpy(&rslt,rsltP,sizeof(T)).wait(); // Copy result to host
       return rslt;
     }
     void deviceReduce(T *data, T *devP) {
-      size_t local_size=0;
-      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
-      auto properties = sycl::property::reduction::initialize_to_identity{};
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
-                                       sycl::reduction(devP, sycl::maximum<>(), properties),
-                                       [=](sycl::nd_item<1> idx, auto& max) {
-                                         max.combine(data[idx.get_global_linear_id()]);
-                                       }).wait();
+      sycl_default_stream.submit([&, nItems = this->nItems](sycl::handler &cgh) {
+          cgh.parallel_for(get_reduction_range(nItems, devP),
+                           sycl::reduction(devP, sycl::maximum<>(), sycl::property::reduction::initialize_to_identity{}),
+                           [=](sycl::nd_item<1> idx, auto& max) {
+                             const int i = idx.get_global_linear_id();
+                             if (i < nItems) {
+                               max.combine(data[i]);
+                             }
+                           });
+        }).wait();
     }
   };
 
@@ -364,27 +393,33 @@ template <class T, int myMem> class ParallelSum;
       rsltP = nullptr;
     }
     T operator() (T *data) {
-      T rslt = 0;
-      size_t local_size=0;
-      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
-      auto properties = sycl::property::reduction::initialize_to_identity{};
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
-                                       sycl::reduction(rsltP, std::plus<>(), properties),
-                                       [=](sycl::nd_item<1> idx, auto& sum) {
-                                         sum.combine(data[idx.get_global_linear_id()]);
-                                       }).wait();
+      T rslt=0;
+      sycl::nd_range<1> res = get_reduction_range(nItems, rsltP);
+      sycl_default_stream.submit([&, nItems = this->nItems](sycl::handler &cgh) {
+          cgh.parallel_for(get_reduction_range(nItems, rsltP),
+                           sycl::reduction(rsltP, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
+                           [=](sycl::nd_item<1> idx, auto& sum) {
+                             const int i = idx.get_global_linear_id();
+                             if (i < nItems) {
+                               sum.combine(data[i]);
+                             }
+                           });
+        }).wait();
+
       sycl_default_stream.memcpy(&rslt,rsltP,sizeof(T)).wait(); // Copy result to host
       return rslt;
     }
     void deviceReduce(T *data, T *devP) {
-      size_t local_size=0;
-      (nItems % 2 == 0) ? (local_size=2) : (local_size=3);
-      auto properties = sycl::property::reduction::initialize_to_identity{};
-      sycl_default_stream.parallel_for(sycl::nd_range<1>{nItems, local_size},
-                                       sycl::reduction(devP, std::plus<>(), properties),
-                                       [=](sycl::nd_item<1> idx, auto& sum) {
-                                         sum.combine(data[idx.get_global_linear_id()]);
-                                       }).wait();
+      sycl_default_stream.submit([&, nItems = this->nItems](sycl::handler &cgh) {
+          cgh.parallel_for(get_reduction_range(nItems, rsltP),
+                           sycl::reduction(rsltP, std::plus<>(), sycl::property::reduction::initialize_to_identity{}),
+                           [=](sycl::nd_item<1> idx, auto& sum) {
+                             const int i = idx.get_global_linear_id();
+                             if (i < nItems) {
+                               sum.combine(data[i]);
+                             }
+                           });
+        }).wait();
     }
   };
 

--- a/unit/build/machines/jlse/jlse_gpu.sh
+++ b/unit/build/machines/jlse/jlse_gpu.sh
@@ -15,7 +15,7 @@ unset CXXFLAGS
 unset FFLAGS
 
 cmake -DYAKL_ARCH="SYCL"        \
-      -DYAKL_SYCL_FLAGS="-O0 -g --intel -fsycl" \
+      -DCMAKE_CXX_FLAGS='-O0 -g -sycl-std=2020 -fsycl -fsycl-unnamed-lambda' \
       -DYAKL_F90_FLAGS="-O0 -g" \
       -DYAKL_C_FLAGS="-O0 -g"   \
       ../../..

--- a/unit/simplified_SYCL/YAKL.h
+++ b/unit/simplified_SYCL/YAKL.h
@@ -16,7 +16,6 @@
 #define YAKL_DEVICE inline
 #define YAKL_SCOPE(a,b) auto &a = std::ref(b).get()
 #include <CL/sycl.hpp>
-namespace sycl = cl::sycl;
 
 namespace yakl {
 


### PR DESCRIPTION
1. Mostly fixing the SYCL kernel launches using `functorBuffer`
2. SYCL reductions bug fixes
3. Limitations: Comment out (`deallocate()`) in YAKL_CArray.h:415, YAKL_FArray.h:498 (Reasons: `error: SYCL kernel cannot use a non-const global variable, error: SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute`)

```
Test project /gpfs/jlse-fs0/users/abagusetty/projects/YAKL/unit/build/machines/jlse
      Start  1: CArray_test
 1/16 Test  #1: CArray_test ......................   Passed    7.55 sec
      Start  2: FArray_test
 2/16 Test  #2: FArray_test ......................   Passed    7.62 sec
      Start  3: Gator_test
 3/16 Test  #3: Gator_test .......................   Passed    0.98 sec
      Start  4: Random_test
 4/16 Test  #4: Random_test ......................   Passed    2.79 sec
      Start  5: FFT_test
 5/16 Test  #5: FFT_test .........................   Passed    1.81 sec
      Start  6: Reductions_test
 6/16 Test  #6: Reductions_test ..................   Passed    5.35 sec
      Start  7: Atomics_test
 7/16 Test  #7: Atomics_test .....................   Passed    2.24 sec
      Start  8: Pentadiagonal_test
 8/16 Test  #8: Pentadiagonal_test ...............   Passed    0.03 sec
      Start  9: Tridiagonal_test
 9/16 Test  #9: Tridiagonal_test .................   Passed    0.01 sec
      Start 10: Lambda_test
10/16 Test #10: Lambda_test ......................   Passed    2.07 sec
      Start 11: Fortran_Link_test
11/16 Test #11: Fortran_Link_test ................Subprocess aborted***Exception:   0.55 sec
      Start 12: Fortran_Gator_test
12/16 Test #12: Fortran_Gator_test ...............   Passed    1.98 sec
      Start 13: OpenMP_Regions_test
13/16 Test #13: OpenMP_Regions_test ..............   Passed    0.47 sec
      Start 14: Intrinsics_test
14/16 Test #14: Intrinsics_test ..................   Passed    2.12 sec
      Start 15: ParForC_test
15/16 Test #15: ParForC_test .....................   Passed    2.23 sec
      Start 16: ParForFortran_test
16/16 Test #16: ParForFortran_test ...............   Passed    2.17 sec

94% tests passed, 1 tests failed out of 16

Total Test time (real) =  40.02 sec

The following tests FAILED:
	 11 - Fortran_Link_test (Subprocess aborted)
```