### PR TITLE
[SYCL] fix sycl barrier from blocking on host to blocking on device-only

### DIFF
--- a/src/YAKL.h
+++ b/src/YAKL.h
@@ -116,7 +116,6 @@ namespace yakl {
       #endif
       #if defined(YAKL_ARCH_SYCL)
         sycl::free(functorBuffer, sycl_default_stream());
-        sycl_default_stream().wait();
         check_last_error();
       #endif
       yakl_is_initialized = false;

--- a/src/YAKL_alloc_free.h
+++ b/src/YAKL_alloc_free.h
@@ -66,34 +66,26 @@ inline void set_alloc_free(std::function<void *( size_t )> &alloc , std::functio
     #if defined (YAKL_MANAGED_MEMORY)
       alloc = [] ( size_t bytes ) -> void* {
         if (bytes == 0) return nullptr;
-        sycl_default_stream().wait();
         void *ptr = sycl::malloc_shared(bytes,sycl_default_stream());
         sycl_default_stream().memset(ptr, 0, bytes);
-        sycl_default_stream().wait();
         check_last_error();
         sycl_default_stream().prefetch(ptr,bytes);
         return ptr;
       };
       dealloc = [] ( void *ptr ) {
-        sycl_default_stream().wait();
         sycl::free(ptr, sycl_default_stream());
-        sycl_default_stream().wait();
         check_last_error();
       };
     #else
       alloc = [] ( size_t bytes ) -> void* {
         if (bytes == 0) return nullptr;
-        sycl_default_stream().wait();
         void *ptr = sycl::malloc_device(bytes,sycl_default_stream());
         sycl_default_stream().memset(ptr, 0, bytes);
-        sycl_default_stream().wait();
         check_last_error();
         return ptr;
       };
       dealloc = [] ( void *ptr ) {
-        sycl_default_stream().wait();
         sycl::free(ptr, sycl_default_stream());
-        sycl_default_stream().wait();
         check_last_error();
         // ptr = nullptr;
       };

--- a/src/YAKL_parallel_for_common.h
+++ b/src/YAKL_parallel_for_common.h
@@ -107,13 +107,15 @@ template <class F, bool simple> YAKL_DEVICE_INLINE void callFunctor(F const &f ,
     if constexpr (sycl::is_device_copyable<F>::value) {
       sycl_default_stream().parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
         callFunctor( f , bounds , i );
-      }).wait();
+      });
+      sycl_default_stream().ext_oneapi_submit_barrier();
     } else {
       F *fp = (F *) functorBuffer;
-      sycl_default_stream().memcpy(fp, &f, sizeof(F)).wait();
+      sycl_default_stream().memcpy(fp, &f, sizeof(F));
       sycl_default_stream().parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
         callFunctor( *fp , bounds , i );
-      }).wait();
+      });
+      sycl_default_stream().ext_oneapi_submit_barrier();
     }
 
     check_last_error();


### PR DESCRIPTION
Some improvements to SYCL barriers. Switching kernel launches from blocking barrier with respect to host to async-barriers