### PR TITLE
[SYCL] oneAPI 2022.1 reductions, AoT

### DIFF
--- a/src/YAKL_atomics.h
+++ b/src/YAKL_atomics.h
@@ -114,9 +114,9 @@
   template <typename T, sycl::access::address_space addressSpace =
       sycl::access::address_space::global_space>
   using relaxed_atomic_ref =
-        sycl::ext::oneapi::atomic_ref< T,
-        sycl::ext::oneapi::memory_order::seq_cst,
-        sycl::ext::oneapi::memory_scope::device,
+        sycl::atomic_ref< T,
+        sycl::memory_order::seq_cst,
+        sycl::memory_scope::device,
         addressSpace>;
 
   template <typename T, sycl::access::address_space addressSpace =

--- a/src/YAKL_parallel_for_common.h
+++ b/src/YAKL_parallel_for_common.h
@@ -108,14 +108,14 @@ template <class F, bool simple> YAKL_DEVICE_INLINE void callFunctor(F const &f ,
       sycl_default_stream().parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
         callFunctor( f , bounds , i );
       });
-      sycl_default_stream().ext_oneapi_submit_barrier();
+      sycl_default_stream().wait();
     } else {
       F *fp = (F *) functorBuffer;
       sycl_default_stream().memcpy(fp, &f, sizeof(F));
       sycl_default_stream().parallel_for( sycl::range<1>(bounds.nIter) , [=] (sycl::id<1> i) {
         callFunctor( *fp , bounds , i );
       });
-      sycl_default_stream().ext_oneapi_submit_barrier();
+      sycl_default_stream().wait();
     }
 
     check_last_error();

--- a/unit/build/machines/jlse/jlse_debug.sh
+++ b/unit/build/machines/jlse/jlse_debug.sh
@@ -2,15 +2,15 @@
 
 source $MODULESHOME/init/bash
 module purge
-module load oneapi cmake
+module load oneapi cmake/3.22.1
 
 ../../cmakeclean.sh
 
 unset GATOR_DISABLE
 
-export CC=mpiicx
-export CXX=mpiicpx
-export FC=mpiifx
+export CC=mpicc
+export CXX=mpicxx
+export FC=mpifort
 unset CXXFLAGS
 unset FFLAGS
 

--- a/unit/build/machines/jlse/jlse_gpu_O1.sh
+++ b/unit/build/machines/jlse/jlse_gpu_O1.sh
@@ -2,15 +2,15 @@
 
 source $MODULESHOME/init/bash
 module purge
-module load oneapi cmake
+module load oneapi cmake/3.22.1
 
 ../../cmakeclean.sh
 
 unset GATOR_DISABLE
 
-export CC=mpiicx
-export CXX=mpiicpx
-export FC=mpiifx
+export CC=mpicc
+export CXX=mpicxx
+export FC=mpifort
 unset CXXFLAGS
 unset FFLAGS
 

--- a/unit/build/machines/jlse/jlse_gpu_O1_debug.sh
+++ b/unit/build/machines/jlse/jlse_gpu_O1_debug.sh
@@ -2,15 +2,15 @@
 
 source $MODULESHOME/init/bash
 module purge
-module load oneapi cmake
+module load oneapi cmake/3.22.1
 
 ../../cmakeclean.sh
 
 unset GATOR_DISABLE
 
-export CC=mpiicx
-export CXX=mpiicpx
-export FC=mpiifx
+export CC=mpicc
+export CXX=mpicxx
+export FC=mpifort
 unset CXXFLAGS
 unset FFLAGS
 

--- a/unit/build/machines/jlse/jlse_gpu_O3_AoT_ATS.sh
+++ b/unit/build/machines/jlse/jlse_gpu_O3_AoT_ATS.sh
@@ -16,7 +16,7 @@ unset FFLAGS
 
 cmake -DYAKL_ARCH="SYCL" \
       -DYAKL_SYCL_FLAGS="-O3" \
-      -DCMAKE_CXX_FLAGS="-O3 -fsycl -sycl-std=2020 -fsycl-unnamed-lambda -fsycl-device-code-split=per_kernel" \
+      -DCMAKE_CXX_FLAGS="-O3 -fsycl -sycl-std=2020 -fsycl-unnamed-lambda -fsycl-device-code-split=per_kernel -fsycl-targets=spir64_gen -Xs \"-device xehp\"" \
       -DYAKL_F90_FLAGS="-O3" \
       -DYAKL_C_FLAGS="-O3"   \
       ../../..

--- a/unit/build/machines/jlse/jlse_gpu_debug.sh
+++ b/unit/build/machines/jlse/jlse_gpu_debug.sh
@@ -2,15 +2,15 @@
 
 source $MODULESHOME/init/bash
 module purge
-module load oneapi cmake
+module load oneapi cmake/3.22.1
 
 ../../cmakeclean.sh
 
 unset GATOR_DISABLE
 
-export CC=mpiicx
-export CXX=mpiicpx
-export FC=mpiifx
+export CC=mpicc
+export CXX=mpicxx
+export FC=mpifort
 unset CXXFLAGS
 unset FFLAGS
 


### PR DESCRIPTION
1. Update SYCL 2020 reductions to use sycl::range over sycl::nd_range
2. Add Ahead of Time (AoT) capabilities for ATS
3. Switch to sync barrier over async barrier for SYCL kernel launches
4. MPI compilers update