### PR TITLE
[SYCL] add MPI binding to GPU logic to SYCL code path

### DIFF
--- a/src/YAKL_sycldevice.h
+++ b/src/YAKL_sycldevice.h
@@ -59,12 +59,16 @@ namespace yakl {
         }
 
 #ifdef HAVE_MPI
-        MPI_Comm shmcomm;
-        MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0,
-                            MPI_INFO_NULL, &shmcomm);
-        int shmrank;
-        MPI_Comm_rank(shmcomm, &shmrank);
-        DEFAULT_DEVICE_ID = (shmrank % _devs.size());
+        int is_initialized;
+        MPI_Initialized(&is_initialized);
+        if (is_initialized) {
+          MPI_Comm shmcomm;
+          MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0,
+                              MPI_INFO_NULL, &shmcomm);
+          int shmrank;
+          MPI_Comm_rank(shmcomm, &shmrank);
+          DEFAULT_DEVICE_ID = (shmrank % _devs.size());
+        }
 #endif // HAVE_MPI
       }
       void check_id(unsigned int id) const {


### PR DESCRIPTION
Some simple MPI binding to SYCL devices per node-local in a round robin fashion

