### PR TITLE
SYCLqueue singleton cleanup

### DIFF
--- a/src/YAKL_sycldevice.h
+++ b/src/YAKL_sycldevice.h
@@ -23,10 +23,8 @@ namespace yakl {
     class dev_mgr {
     public:
       sycl::queue &default_queue() {
-        check_id(DEFAULT_DEVICE_ID);
-        return *(_queues[DEFAULT_DEVICE_ID].get());
+        return *(_queues.get());
       }
-      unsigned int device_count() { return _devs.size(); }
 
       /// Returns the instance of device manager singleton.
       static dev_mgr &instance() {
@@ -40,33 +38,14 @@ namespace yakl {
 
     private:
       dev_mgr() {
-        auto gpu_devs = sycl::device::get_devices(sycl::info::device_type::gpu);
-        for (auto &dev : gpu_devs) {
-          if (dev.get_info<sycl::info::device::partition_max_sub_devices>() > 0) {
-            auto subDevs = dev.create_sub_devices<sycl::info::partition_property::partition_by_affinity_domain>(sycl::info::partition_affinity_domain::numa);
-            for (auto &sub_dev : subDevs) {
-              _devs.push_back(std::make_shared<sycl::device>(sub_dev));
-              _queues.push_back(std::make_shared<sycl::queue>(sub_dev,
-                                                              asyncHandler,
-                                                              sycl::property_list{sycl::property::queue::in_order{}}));
-            }
-          } else {
-            _devs.push_back(std::make_shared<sycl::device>(dev));
-            _queues.push_back(std::make_shared<sycl::queue>(dev,
-                                                            asyncHandler,
-                                                            sycl::property_list{sycl::property::queue::in_order{}}));
-          }
-        }
+	sycl::device dev(sycl::gpu_selector{});
+	_devs = std::make_shared<sycl::device>(dev);
+	_queues = std::make_shared<sycl::queue>(dev,
+						asyncHandler,
+						sycl::property_list{sycl::property::queue::in_order{}});
       }
-      void check_id(unsigned int id) const {
-        if (id >= _devs.size()) {
-          std::cerr << "ERROR: invalid SYCL device id \n";
-        }
-      }
-      std::vector<std::shared_ptr<sycl::device>> _devs;
-      std::vector<std::shared_ptr<sycl::queue>> _queues;
-
-      unsigned int DEFAULT_DEVICE_ID = 0;
+      std::shared_ptr<sycl::device> _devs;
+      std::shared_ptr<sycl::queue> _queues;
     };
 
     static inline sycl::queue &sycl_default_stream() {


### PR DESCRIPTION
1. Removed obsolete logic to track queues from multi-devices
2. Reflects similar in functionality like CUDA, HIP