### PR TITLE
Make signature of wait_on_event match definition

### DIFF
--- a/src/YAKL_streams_events.h
+++ b/src/YAKL_streams_events.h
@@ -390,7 +390,7 @@ namespace yakl {
       /** @brief Determine if this stream is the same as the passed stream */
       bool operator==(Stream stream) const { return true; }
       /** @brief Tell the stream to wait until the passed event completes before continuing work in the stream. */
-      inline void wait_on_event(Event& event);
+      inline void wait_on_event(Event event);
       /** @brief Determine whether this stream is the default stream. */
       bool is_default_stream() { return true; }
       /** @brief Pause all CPU work until all existing work in this stream completes. */


### PR DESCRIPTION
Not sure why this was part of #81, but it breaks compilation. If it was for consistency with the SYCL version, then all implementations should pass `const Event&`, non-const `Event&` doesn't work. 