### PR TITLE
Creating a routine to subset the slowest dimension to support slices with ranges on slowest dimension

### DIFF
--- a/src/YAKL_CArray.h
+++ b/src/YAKL_CArray.h
@@ -656,6 +656,34 @@ namespace yakl {
     }
 
 
+    /** @brief Return an array aliasing a contiguous subset of the slowest dimension */
+    YAKL_INLINE Array<T,rank,myMem,styleC> subset_slowest_dimension(int u) const { return subset_slowest_dimension(0,u); }
+
+
+    /** @brief Return an array aliasing a contiguous subset of the slowest dimension */
+    YAKL_INLINE Array<T,rank,myMem,styleC> subset_slowest_dimension(int l, int u) const {
+      #ifdef YAKL_DEBUG
+        if (! this->initialized()) { yakl_throw("ERROR: Trying to subset_slowest_dimension an Array that hasn't been initialized"); }
+        if (l < 0) { yakl_throw("ERROR: subset_slowest_dimension lower bound < 0"); }
+        if (u < 0) { yakl_throw("ERROR: subset_slowest_dimension upper bound < 0"); }
+        if (l > u) { yakl_throw("ERROR: subset_slowest_dimension lower bound > upper bounds"); }
+        if (u > this->dimension[0]-1) { yakl_throw("ERROR: subset_slowest_dimension upper bound out of bounds"); }
+      #endif
+      auto ret = *this;
+      auto &d = this->dimension;
+      if constexpr (rank == 1) ret.myData += l;
+      if constexpr (rank == 2) ret.myData += l*d[1];
+      if constexpr (rank == 3) ret.myData += l*d[1]*d[2];
+      if constexpr (rank == 4) ret.myData += l*d[1]*d[2]*d[3];
+      if constexpr (rank == 5) ret.myData += l*d[1]*d[2]*d[3]*d[4];
+      if constexpr (rank == 6) ret.myData += l*d[1]*d[2]*d[3]*d[4]*d[5];
+      if constexpr (rank == 7) ret.myData += l*d[1]*d[2]*d[3]*d[4]*d[5]*d[6];
+      if constexpr (rank == 8) ret.myData += l*d[1]*d[2]*d[3]*d[4]*d[5]*d[6]*d[7];
+      ret.dimension[0] = u-l+1;
+      return ret;
+    }
+
+
     /** @class doxhide_CArray_slicing
       * @brief dummy
       *

--- a/src/YAKL_FArray.h
+++ b/src/YAKL_FArray.h
@@ -671,6 +671,35 @@ namespace yakl {
     }
 
 
+
+    YAKL_INLINE Array<T,rank,myMem,styleFortran> subset_slowest_dimension(int u) const { return subset_slowest_dimension(lbounds[rank-1],u); }
+
+
+    /** @brief Return an array aliasing a contiguous subset of the slowest dimension */
+    YAKL_INLINE Array<T,rank,myMem,styleFortran> subset_slowest_dimension(int l, int u) const {
+      #ifdef YAKL_DEBUG
+        if (! this->initialized()) { yakl_throw("ERROR: Trying to subset_slowest_dimension an Array that hasn't been initialized"); }
+        if (l < lbounds[rank-1]) { yakl_throw("ERROR: subset_slowest_dimension lower bound too low"); }
+        if (u < lbounds[rank-1]) { yakl_throw("ERROR: subset_slowest_dimension upper bound too low"); }
+        if (l > u) { yakl_throw("ERROR: subset_slowest_dimension lower bound > upper bounds"); }
+        if (u >= this->lbounds[rank-1]+this->dimension[rank-1]) { yakl_throw("ERROR: subset_slowest_dimension upper bound too high"); }
+      #endif
+      auto ret = *this;
+      auto &lb = this->lbounds;
+      auto &d  = this->dimension;
+      if constexpr (rank == 1) ret.myData += (l-lb[rank-1]);
+      if constexpr (rank == 2) ret.myData += (l-lb[rank-1])*d[0];
+      if constexpr (rank == 3) ret.myData += (l-lb[rank-1])*d[0]*d[1];
+      if constexpr (rank == 4) ret.myData += (l-lb[rank-1])*d[0]*d[1]*d[2];
+      if constexpr (rank == 5) ret.myData += (l-lb[rank-1])*d[0]*d[1]*d[2]*d[3];
+      if constexpr (rank == 6) ret.myData += (l-lb[rank-1])*d[0]*d[1]*d[2]*d[3]*d[4];
+      if constexpr (rank == 7) ret.myData += (l-lb[rank-1])*d[0]*d[1]*d[2]*d[3]*d[4]*d[5];
+      if constexpr (rank == 8) ret.myData += (l-lb[rank-1])*d[0]*d[1]*d[2]*d[3]*d[4]*d[5]*d[6];
+      ret.dimension[rank-1] = u-l+1;
+      return ret;
+    }
+
+
     /** @class doxhide_FArray_slicing
       * @brief dummy
       *

--- a/unit/CArray/CArray.cpp
+++ b/unit/CArray/CArray.cpp
@@ -372,6 +372,13 @@ int main() {
     constDevArr.deallocate();
     if (constDevArr.initialized()) die("constDevArr: array didn't deallocate properly");
 
+    ///////////////////////////////////////////////////////////
+    // Test subset_slowest_dimension
+    ///////////////////////////////////////////////////////////
+    test8d = 1;
+    test8d.subset_slowest_dimension(0) = 2;
+    if (yakl::intrinsics::sum(test8d) != d2*d3*d4*d5*d6*d7*d8*3) { die("SimpleBounds: wrong sum for reshaped subset"); }
+
   }
   yakl::finalize();
   

--- a/unit/FArray/FArray.cpp
+++ b/unit/FArray/FArray.cpp
@@ -383,6 +383,13 @@ int main() {
     constDevArr.deallocate();
     if (constDevArr.initialized()) die("constDevArr: array didn't deallocate properly");
 
+    ///////////////////////////////////////////////////////////
+    // Test subset_slowest_dimension
+    ///////////////////////////////////////////////////////////
+    test7d = 1;
+    test7d.subset_slowest_dimension(2) = 2;
+    if (yakl::intrinsics::sum(test7d) != d1*d2*d3*d4*d5*d6*5) { die("SimpleBounds: wrong sum for reshaped subset"); }
+
   }
   yakl::finalize();
   


### PR DESCRIPTION
Creating a routine to subset the slowest dimension to support slices with a range on the slowest dimension

One can write: `myslice = arr.slice<N>(...).subset_slowest_dimension(l,u);`