### PR TITLE
[SYCL] sets env ZES_ENABLE_SYSMAN for correct behavior, if not set

### DIFF
--- a/src/YAKL_InitConfig.h
+++ b/src/YAKL_InitConfig.h
@@ -9,12 +9,12 @@
 
 __YAKL_NAMESPACE_WRAPPER_BEGIN__
 namespace yakl {
-  
+
   /** @brief An object of this class can optionally be passed to yakl::init() to configure the initialization.
     *        **IMPORTANT**: Creating an InitConfig object pings environment
     *        variables, making it quite expensive to create. Please do not create a lot of these.
     * @details This allows the user to override timer, allocation, and deallocation routines.
-    * 
+    *
     * All `set_` functions return the InitConfig object they were called on. Therefore, the user can code, e.g.,
     * `yakl::init(yakl::InitConfig().set_device_allocator(myalloc).set_device_deallocator(myfree));` */
   class InitConfig {
@@ -22,7 +22,7 @@ namespace yakl {
     /** @private */
     std::function<void *( size_t , char const *)> alloc_device_func;
     /** @private */
-    std::function<void ( void * , char const *)>  free_device_func;  
+    std::function<void ( void * , char const *)>  free_device_func;
     /** @private */
     std::function<void ()>                        timer_init;
     /** @private */
@@ -39,7 +39,7 @@ namespace yakl {
     size_t pool_grow_mb;
     /** @private */
     size_t pool_block_bytes;
-  
+
   public:
     /** @brief Creating an InitConfig() controls the memory pool parameters, timer function overrides, and device
       *        allocation and deallocation overrides. **IMPORTANT**: Creating an InitConfig object pings environment
@@ -55,6 +55,7 @@ namespace yakl {
         mem_free  /= 1024*1024;
         mem_total /= 1024*1024;
       #elif defined(YAKL_ARCH_SYCL)
+        setenv("ZES_ENABLE_SYSMAN", "1", 0);
         mem_total = sycl_default_stream().get_device().get_info<sycl::info::device::global_mem_size>();
         mem_free  = sycl_default_stream().get_device().get_info<sycl::ext::intel::info::device::free_memory>();
         mem_free  /= 1024*1024;
@@ -169,5 +170,3 @@ namespace yakl {
 
 }
 __YAKL_NAMESPACE_WRAPPER_END__
-
-


### PR DESCRIPTION
If the env is already set, the api is a no-op.