### PR TITLE
Change from unsigned int to size_t

### DIFF
--- a/src/YAKL.h
+++ b/src/YAKL.h
@@ -29,7 +29,6 @@ using namespace YAKL_NAMESPACE_WRAPPER_LABEL ;
 
 __YAKL_NAMESPACE_WRAPPER_BEGIN__
 namespace yakl {
-  typedef unsigned int uint;
   using std::cos;
   using std::sin;
   using std::pow;
@@ -37,8 +36,8 @@ namespace yakl {
   using std::max;
   using std::abs;
 
-  // Type for indexing. Rarely if ever is size_t going to be needed
-  typedef unsigned int index_t;
+  // Type for indexing.
+  typedef size_t index_t;
   index_t constexpr INDEX_MAX = std::numeric_limits<index_t>::max();
 }
 __YAKL_NAMESPACE_WRAPPER_END__

--- a/src/YAKL_Array.h
+++ b/src/YAKL_Array.h
@@ -153,7 +153,7 @@ namespace yakl {
     }
 
     /** @brief This constructor allows converting a CSArray object to a yakl::Dims object. */
-    template <class INT, unsigned int RANK, typename std::enable_if< std::is_integral<INT>::value , bool>::type = false>
+    template <class INT, index_t RANK, typename std::enable_if< std::is_integral<INT>::value , bool>::type = false>
     Dims(CSArray<INT,1,RANK> const dims) {
       rank = RANK;
       for (int i=0; i < rank; i++) { data[i] = dims(i); }
@@ -309,7 +309,7 @@ namespace yakl {
 
     /** @brief Allows CSArray object to be converted to a yakl::Bnds object if default lower bounds of 1 are desired for
       *        all dimensions. */
-    template <class INT, unsigned int RANK, typename std::enable_if< std::is_integral<INT>::value , bool>::type = false>
+    template <class INT, index_t RANK, typename std::enable_if< std::is_integral<INT>::value , bool>::type = false>
     Bnds(CSArray<INT,1,RANK> const dims) {
       rank = RANK;
       for (int i=0; i < rank; i++) { l[i] = 1;   u[i] = dims(i); }

--- a/src/YAKL_CSArray.h
+++ b/src/YAKL_CSArray.h
@@ -59,7 +59,7 @@ namespace yakl {
     /** @brief Returns a reference to the indexed element (1-D).
       * @details Number of indices must match the rank of the array object. For bounds checking, define the CPP macro `YAKL_DEBUG`.
       * Always use zero-based indexing with row-major ordering (right-most index varying the fastest). */
-    YAKL_INLINE T &operator()(uint const i0) const {
+    YAKL_INLINE T &operator()(index_t const i0) const {
       static_assert(rank==1,"ERROR: Improper number of dimensions specified in operator()");
       #ifdef YAKL_DEBUG
           if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %d; lb0: %d; ub0: %d)\n",i0,0,D0-1); ) } }
@@ -70,7 +70,7 @@ namespace yakl {
     /** @brief Returns a reference to the indexed element (2-D).
       * @details Number of indices must match the rank of the array object. For bounds checking, define the CPP macro `YAKL_DEBUG`.
       * Always use zero-based indexing with row-major ordering (right-most index varying the fastest). */
-    YAKL_INLINE T &operator()(uint const i0, uint const i1) const {
+    YAKL_INLINE T &operator()(index_t const i0, index_t const i1) const {
       static_assert(rank==2,"ERROR: Improper number of dimensions specified in operator()");
       #ifdef YAKL_DEBUG
         if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %d; lb0: %d; ub0: %d)\n",i0,0,D0-1); ) } }
@@ -83,7 +83,7 @@ namespace yakl {
     /** @brief Returns a reference to the indexed element (3-D).
       * @details Number of indices must match the rank of the array object. For bounds checking, define the CPP macro `YAKL_DEBUG`.
       * Always use zero-based indexing with row-major ordering (right-most index varying the fastest). */
-    YAKL_INLINE T &operator()(uint const i0, uint const i1, uint const i2) const {
+    YAKL_INLINE T &operator()(index_t const i0, index_t const i1, index_t const i2) const {
       static_assert(rank==3,"ERROR: Improper number of dimensions specified in operator()");
       #ifdef YAKL_DEBUG
         if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %d; lb0: %d; ub0: %d)\n",i0,0,D0-1); ) } }
@@ -98,7 +98,7 @@ namespace yakl {
     /** @brief Returns a reference to the indexed element (4-D).
       * @details Number of indices must match the rank of the array object. For bounds checking, define the CPP macro `YAKL_DEBUG`.
       * Always use zero-based indexing with row-major ordering (right-most index varying the fastest). */
-    YAKL_INLINE T &operator()(uint const i0, uint const i1, uint const i2, uint const i3) const {
+    YAKL_INLINE T &operator()(index_t const i0, index_t const i1, index_t const i2, index_t const i3) const {
       static_assert(rank==4,"ERROR: Improper number of dimensions specified in operator()");
       #ifdef YAKL_DEBUG
         if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %d; lb0: %d; ub0: %d)\n",i0,0,D0-1); ) } }
@@ -145,7 +145,7 @@ namespace yakl {
 
     /** @brief Print out the contents of this array. This should be called only from the host */
     inline friend std::ostream &operator<<(std::ostream& os, CSArray<T,rank,D0,D1,D2,D3> const &v) {
-      for (uint i=0; i<totElems(); i++) { os << std::setw(12) << v.myData[i] << "\n"; }
+      for (index_t i=0; i<totElems(); i++) { os << std::setw(12) << v.myData[i] << "\n"; }
       os << "\n";
       return os;
     }
@@ -154,8 +154,8 @@ namespace yakl {
     /** @brief Returns the dimensions of this array as a yakl::SArray object.
       * 
       * You should use zero-based indexing on the returned SArray object. */
-    YAKL_INLINE CSArray<uint,1,rank> get_dimensions() const {
-      CSArray<uint,1,rank> ret;
+    YAKL_INLINE CSArray<index_t,1,rank> get_dimensions() const {
+      CSArray<index_t,1,rank> ret;
       if constexpr (rank >= 1) ret(0) = D0;
       if constexpr (rank >= 2) ret(1) = D1;
       if constexpr (rank >= 3) ret(2) = D2;
@@ -165,8 +165,8 @@ namespace yakl {
     /** @brief Returns the lower bound of each dimension of this array as a yakl::SArray object.
       * 
       * You should use zero-based indexing on the returned yakl::SArray object. */
-    YAKL_INLINE CSArray<uint,1,rank> get_lbounds() const {
-      CSArray<uint,1,rank> ret;
+    YAKL_INLINE CSArray<index_t,1,rank> get_lbounds() const {
+      CSArray<index_t,1,rank> ret;
       if constexpr (rank >= 1) ret(0) = 0;
       if constexpr (rank >= 2) ret(1) = 0;
       if constexpr (rank >= 3) ret(2) = 0;
@@ -176,8 +176,8 @@ namespace yakl {
     /** @brief Returns the upper bound of each dimension of this array as a yakl::SArray object.
       *
       * You should use zero-based indexing on the returned yakl::SArray object. */
-    YAKL_INLINE CSArray<uint,1,rank> get_ubounds() const {
-      CSArray<uint,1,rank> ret;
+    YAKL_INLINE CSArray<index_t,1,rank> get_ubounds() const {
+      CSArray<index_t,1,rank> ret;
       if constexpr (rank >= 1) ret(0) = D0-1;
       if constexpr (rank >= 2) ret(1) = D1-1;
       if constexpr (rank >= 3) ret(2) = D2-1;

--- a/src/YAKL_CSArray.h
+++ b/src/YAKL_CSArray.h
@@ -26,17 +26,17 @@ namespace yakl {
     * Creating these arrays is very cheap, but copying them does a deep copy every time and can be expensive.
     * yakl::SArray objects should be indexed with zero-based indices in row-major order (right-most index varies the fastest)
     */
-  template <class T, int rank, unsigned D0, unsigned D1=1, unsigned D2=1, unsigned D3=1>
+  template <class T, int rank, index_t D0, index_t D1=1, index_t D2=1, index_t D3=1>
   class CSArray {
   protected:
     /** @private */
-    static unsigned constexpr OFF0 = D3*D2*D1;
+    static index_t constexpr OFF0 = D3*D2*D1;
     /** @private */
-    static unsigned constexpr OFF1 = D3*D2;
+    static index_t constexpr OFF1 = D3*D2;
     /** @private */
-    static unsigned constexpr OFF2 = D3;
+    static index_t constexpr OFF2 = D3;
     /** @private */
-    static unsigned constexpr OFF3 = 1;
+    static index_t constexpr OFF3 = 1;
     /** @private */
     T mutable myData[D0*D1*D2*D3];
 
@@ -128,15 +128,15 @@ namespace yakl {
     /** @brief Returns pointer to end of the data */
     YAKL_INLINE T *end() const { return begin() + size(); }
     /** @brief Get the total number of array elements */
-    static unsigned constexpr totElems      () { return D3*D2*D1*D0; }
+    static index_t constexpr totElems      () { return D3*D2*D1*D0; }
     /** @brief Get the total number of array elements */
-    static unsigned constexpr get_totElems  () { return D3*D2*D1*D0; }
+    static index_t constexpr get_totElems  () { return D3*D2*D1*D0; }
     /** @brief Get the total number of array elements */
-    static unsigned constexpr size          () { return D3*D2*D1*D0; }
+    static index_t constexpr size          () { return D3*D2*D1*D0; }
     /** @brief Get the total number of array elements */
-    static unsigned constexpr get_elem_count() { return D3*D2*D1*D0; }
+    static index_t constexpr get_elem_count() { return D3*D2*D1*D0; }
     /** @brief Get the number of dimensions */
-    static unsigned constexpr get_rank      () { return rank; }
+    static index_t constexpr get_rank      () { return rank; }
     /** @brief Always true. All YAKL arrays are contiguous with no padding. */
     static bool     constexpr span_is_contiguous() { return true; }
     /** @brief Always true. yakl::SArray objects are by default always initialized / allocated. */
@@ -190,7 +190,7 @@ namespace yakl {
 
 
   /** @brief Most often, codes use the type define yakl::SArray rather than yakl::CSArray */
-  template <class T, int rank, unsigned D0, unsigned D1=1, unsigned D2=1, unsigned D3=1>
+  template <class T, int rank, index_t D0, index_t D1=1, index_t D2=1, index_t D3=1>
   using SArray = CSArray<T,rank,D0,D1,D2,D3>;
 
 }

--- a/src/YAKL_CSArray.h
+++ b/src/YAKL_CSArray.h
@@ -62,7 +62,7 @@ namespace yakl {
     YAKL_INLINE T &operator()(index_t const i0) const {
       static_assert(rank==1,"ERROR: Improper number of dimensions specified in operator()");
       #ifdef YAKL_DEBUG
-          if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %d; lb0: %d; ub0: %d)\n",i0,0,D0-1); ) } }
+          if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %zu; lb0: %d; ub0: %zu)\n",i0,0,D0-1); ) } }
           if constexpr (rank >= 1) { if (i0>D0-1) { yakl_throw("ERROR: CSArray index out of bounds"); } }
       #endif
       return myData[i0];
@@ -73,8 +73,8 @@ namespace yakl {
     YAKL_INLINE T &operator()(index_t const i0, index_t const i1) const {
       static_assert(rank==2,"ERROR: Improper number of dimensions specified in operator()");
       #ifdef YAKL_DEBUG
-        if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %d; lb0: %d; ub0: %d)\n",i0,0,D0-1); ) } }
-        if constexpr (rank >= 2) { if (i1>D1-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i1 out of bounds (i1: %d; lb1: %d; ub1: %d)\n",i1,0,D1-1); ) } }
+        if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %zu; lb0: %d; ub0: %zu)\n",i0,0,D0-1); ) } }
+        if constexpr (rank >= 2) { if (i1>D1-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i1 out of bounds (i1: %zu; lb1: %d; ub1: %zu)\n",i1,0,D1-1); ) } }
         if constexpr (rank >= 1) { if (i0>D0-1) { yakl_throw("ERROR: CSArray index out of bounds"); } }
         if constexpr (rank >= 2) { if (i1>D1-1) { yakl_throw("ERROR: CSArray index out of bounds"); } }
       #endif
@@ -86,9 +86,9 @@ namespace yakl {
     YAKL_INLINE T &operator()(index_t const i0, index_t const i1, index_t const i2) const {
       static_assert(rank==3,"ERROR: Improper number of dimensions specified in operator()");
       #ifdef YAKL_DEBUG
-        if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %d; lb0: %d; ub0: %d)\n",i0,0,D0-1); ) } }
-        if constexpr (rank >= 2) { if (i1>D1-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i1 out of bounds (i1: %d; lb1: %d; ub1: %d)\n",i1,0,D1-1); ) } }
-        if constexpr (rank >= 3) { if (i2>D2-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i2 out of bounds (i2: %d; lb2: %d; ub2: %d)\n",i2,0,D2-1); ) } }
+        if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %zu; lb0: %d; ub0: %zu)\n",i0,0,D0-1); ) } }
+        if constexpr (rank >= 2) { if (i1>D1-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i1 out of bounds (i1: %zu; lb1: %d; ub1: %zu)\n",i1,0,D1-1); ) } }
+        if constexpr (rank >= 3) { if (i2>D2-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i2 out of bounds (i2: %zu; lb2: %d; ub2: %zu)\n",i2,0,D2-1); ) } }
         if constexpr (rank >= 1) { if (i0>D0-1) { yakl_throw("ERROR: CSArray index out of bounds"); } }
         if constexpr (rank >= 2) { if (i1>D1-1) { yakl_throw("ERROR: CSArray index out of bounds"); } }
         if constexpr (rank >= 3) { if (i2>D2-1) { yakl_throw("ERROR: CSArray index out of bounds"); } }
@@ -101,10 +101,10 @@ namespace yakl {
     YAKL_INLINE T &operator()(index_t const i0, index_t const i1, index_t const i2, index_t const i3) const {
       static_assert(rank==4,"ERROR: Improper number of dimensions specified in operator()");
       #ifdef YAKL_DEBUG
-        if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %d; lb0: %d; ub0: %d)\n",i0,0,D0-1); ) } }
-        if constexpr (rank >= 2) { if (i1>D1-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i1 out of bounds (i1: %d; lb1: %d; ub1: %d)\n",i1,0,D1-1); ) } }
-        if constexpr (rank >= 3) { if (i2>D2-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i2 out of bounds (i2: %d; lb2: %d; ub2: %d)\n",i2,0,D2-1); ) } }
-        if constexpr (rank >= 4) { if (i3>D3-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i3 out of bounds (i3: %d; lb3: %d; ub3: %d)\n",i3,0,D3-1); ) } }
+        if constexpr (rank >= 1) { if (i0>D0-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i0 out of bounds (i0: %zu; lb0: %d; ub0: %zu)\n",i0,0,D0-1); ) } }
+        if constexpr (rank >= 2) { if (i1>D1-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i1 out of bounds (i1: %zu; lb1: %d; ub1: %zu)\n",i1,0,D1-1); ) } }
+        if constexpr (rank >= 3) { if (i2>D2-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i2 out of bounds (i2: %zu; lb2: %d; ub2: %zu)\n",i2,0,D2-1); ) } }
+        if constexpr (rank >= 4) { if (i3>D3-1) { YAKL_EXECUTE_ON_HOST_ONLY( printf("CSArray i3 out of bounds (i3: %zu; lb3: %d; ub3: %zu)\n",i3,0,D3-1); ) } }
         if constexpr (rank >= 1) { if (i0>D0-1) { yakl_throw("ERROR: CSArray index out of bounds"); } }
         if constexpr (rank >= 2) { if (i1>D1-1) { yakl_throw("ERROR: CSArray index out of bounds"); } }
         if constexpr (rank >= 3) { if (i2>D2-1) { yakl_throw("ERROR: CSArray index out of bounds"); } }

--- a/src/YAKL_FSArray.h
+++ b/src/YAKL_FSArray.h
@@ -69,25 +69,25 @@ namespace yakl {
     /** @private */
     static int constexpr L3 = B3::lower();
     /** @private */
-    static unsigned constexpr D0 =             U0 - L0 + 1;
+    static index_t constexpr D0 =             U0 - L0 + 1;
     /** @private */
-    static unsigned constexpr D1 = rank >= 1 ? U1 - L1 + 1 : 1;
+    static index_t constexpr D1 = rank >= 1 ? U1 - L1 + 1 : 1;
     /** @private */
-    static unsigned constexpr D2 = rank >= 1 ? U2 - L2 + 1 : 1;
+    static index_t constexpr D2 = rank >= 1 ? U2 - L2 + 1 : 1;
     /** @private */
-    static unsigned constexpr D3 = rank >= 1 ? U3 - L3 + 1 : 1;
+    static index_t constexpr D3 = rank >= 1 ? U3 - L3 + 1 : 1;
     /** @private */
-    static unsigned constexpr OFF0 = 1;
+    static index_t constexpr OFF0 = 1;
     /** @private */
-    static unsigned constexpr OFF1 = D0;
+    static index_t constexpr OFF1 = D0;
     /** @private */
-    static unsigned constexpr OFF2 = D0*D1;
+    static index_t constexpr OFF2 = D0*D1;
     /** @private */
     /** @private */
     T mutable myData[D0*D1*D2*D3];
 
   public :
-    static unsigned constexpr OFF3 = D0*D1*D2;
+    static index_t constexpr OFF3 = D0*D1*D2;
 
     /** @brief This is the type `T` without `const` and `volatile` modifiers */
     typedef typename std::remove_cv<T>::type       type;
@@ -176,15 +176,15 @@ namespace yakl {
     /** @brief Returns pointer to end of the data */
     YAKL_INLINE T *end() const { return begin() + size(); }
     /** @brief Get the total number of array elements */
-    static unsigned constexpr totElems      () { return D3*D2*D1*D0; }
+    static index_t constexpr totElems      () { return D3*D2*D1*D0; }
     /** @brief Get the total number of array elements */
-    static unsigned constexpr get_totElems  () { return D3*D2*D1*D0; }
+    static index_t constexpr get_totElems  () { return D3*D2*D1*D0; }
     /** @brief Get the total number of array elements */
-    static unsigned constexpr get_elem_count() { return D3*D2*D1*D0; }
+    static index_t constexpr get_elem_count() { return D3*D2*D1*D0; }
     /** @brief Get the total number of array elements */
-    static unsigned constexpr size          () { return D3*D2*D1*D0; }
+    static index_t constexpr size          () { return D3*D2*D1*D0; }
     /** @brief Get the number of dimensions */
-    static unsigned constexpr get_rank      () { return rank; }
+    static index_t constexpr get_rank      () { return rank; }
     /** @brief Always true. All YAKL arrays are contiguous with no padding. */
     static bool     constexpr span_is_contiguous() { return true; }
     /** @brief Always true. yakl::SArray objects are by default always initialized / allocated. */

--- a/src/YAKL_Toney.h
+++ b/src/YAKL_Toney.h
@@ -28,7 +28,7 @@ namespace yakl {
     struct Timer {
       std::string         label;
       size_t              label_hash;
-      unsigned int        hits;
+      size_t              hits;
       Duration            accumulated_duration;
       Duration            max_duration;
       Duration            min_duration;

--- a/src/YAKL_memset.h
+++ b/src/YAKL_memset.h
@@ -62,7 +62,7 @@ namespace yakl {
 
 
   /** @private */
-  template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3, class I>
+  template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3, class I>
   YAKL_INLINE void memset( SArray<T,rank,D0,D1,D2,D3> &arr , I val ) {
     for (index_t i = 0; i < arr.totElems(); i++) {
       arr.data()[i] = val;

--- a/src/extensions/YAKL_componentwise.h
+++ b/src/extensions/YAKL_componentwise.h
@@ -41,7 +41,7 @@ namespace yakl {
     operator+( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return add_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()+T2()),N,D0,D1,D2,D3>
     operator+( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -82,7 +82,7 @@ namespace yakl {
     operator-( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return sub_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()-T2()),N,D0,D1,D2,D3>
     operator-( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -123,7 +123,7 @@ namespace yakl {
     operator*( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return mult_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()*T2()),N,D0,D1,D2,D3>
     operator*( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -164,7 +164,7 @@ namespace yakl {
     operator/( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return div_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()/T2()),N,D0,D1,D2,D3>
     operator/( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -205,7 +205,7 @@ namespace yakl {
     operator>( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return gt_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()>T2()),N,D0,D1,D2,D3>
     operator>( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -246,7 +246,7 @@ namespace yakl {
     operator<( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return lt_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()<T2()),N,D0,D1,D2,D3>
     operator<( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -287,7 +287,7 @@ namespace yakl {
     operator>=( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return ge_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()>=T2()),N,D0,D1,D2,D3>
     operator>=( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -328,7 +328,7 @@ namespace yakl {
     operator<=( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return le_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()<=T2()),N,D0,D1,D2,D3>
     operator<=( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -369,7 +369,7 @@ namespace yakl {
     operator==( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return eq_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()==T2()),N,D0,D1,D2,D3>
     operator==( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -410,7 +410,7 @@ namespace yakl {
     operator!=( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return ne_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()!=T2()),N,D0,D1,D2,D3>
     operator!=( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -451,7 +451,7 @@ namespace yakl {
     operator&&( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return and_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()&&T2()),N,D0,D1,D2,D3>
     operator&&( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -492,7 +492,7 @@ namespace yakl {
     operator||( Array<T1,N,memDevice,STYLE> const &left , T2 const &right ) {
       return or_array_scalar( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T2>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()||T2()),N,D0,D1,D2,D3>
     operator||( SArray<T1,N,D0,D1,D2,D3> const &left , T2 const &right ) {
@@ -538,7 +538,7 @@ namespace yakl {
     operator+( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return add_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()+T2()),N,D0,D1,D2,D3>
     operator+( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -579,7 +579,7 @@ namespace yakl {
     operator-( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return sub_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()-T2()),N,D0,D1,D2,D3>
     operator-( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -620,7 +620,7 @@ namespace yakl {
     operator*( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return mult_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()*T2()),N,D0,D1,D2,D3>
     operator*( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -661,7 +661,7 @@ namespace yakl {
     operator/( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return div_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()/T2()),N,D0,D1,D2,D3>
     operator/( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -702,7 +702,7 @@ namespace yakl {
     operator>( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return gt_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()>T2()),N,D0,D1,D2,D3>
     operator>( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -743,7 +743,7 @@ namespace yakl {
     operator<( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return lt_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()<T2()),N,D0,D1,D2,D3>
     operator<( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -784,7 +784,7 @@ namespace yakl {
     operator>=( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return ge_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()>=T2()),N,D0,D1,D2,D3>
     operator>=( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -825,7 +825,7 @@ namespace yakl {
     operator<=( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return le_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()<=T2()),N,D0,D1,D2,D3>
     operator<=( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -866,7 +866,7 @@ namespace yakl {
     operator==( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return eq_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()==T2()),N,D0,D1,D2,D3>
     operator==( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -907,7 +907,7 @@ namespace yakl {
     operator!=( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return ne_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()!=T2()),N,D0,D1,D2,D3>
     operator!=( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -948,7 +948,7 @@ namespace yakl {
     operator&&( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return and_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()&&T2()),N,D0,D1,D2,D3>
     operator&&( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -989,7 +989,7 @@ namespace yakl {
     operator||( T1 const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return or_scalar_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3,
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3,
               typename std::enable_if<std::is_arithmetic<T1>::value,bool>::type = false>
     YAKL_INLINE SArray<decltype(T1()||T2()),N,D0,D1,D2,D3>
     operator||( T1 const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
@@ -1028,7 +1028,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()+T2()),N,D0,D1,D2,D3>
     operator+( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()+T2()),N,D0,D1,D2,D3> ret;
@@ -1060,7 +1060,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()-T2()),N,D0,D1,D2,D3>
     operator-( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()-T2()),N,D0,D1,D2,D3> ret;
@@ -1092,7 +1092,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()*T2()),N,D0,D1,D2,D3>
     operator*( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()*T2()),N,D0,D1,D2,D3> ret;
@@ -1124,7 +1124,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()/T2()),N,D0,D1,D2,D3>
     operator/( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()/T2()),N,D0,D1,D2,D3> ret;
@@ -1156,7 +1156,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()>T2()),N,D0,D1,D2,D3>
     operator>( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()>T2()),N,D0,D1,D2,D3> ret;
@@ -1193,7 +1193,7 @@ namespace yakl {
     operator<( Array<T1,N,memDevice,STYLE> const &left , Array<T2,N,memDevice,STYLE> const &right ) {
       return lt_array_array( left , right );
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()<T2()),N,D0,D1,D2,D3>
     operator<( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()<T2()),N,D0,D1,D2,D3> ret;
@@ -1225,7 +1225,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()>=T2()),N,D0,D1,D2,D3>
     operator>=( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()>=T2()),N,D0,D1,D2,D3> ret;
@@ -1257,7 +1257,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()<=T2()),N,D0,D1,D2,D3>
     operator<=( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()<=T2()),N,D0,D1,D2,D3> ret;
@@ -1289,7 +1289,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()==T2()),N,D0,D1,D2,D3>
     operator==( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()==T2()),N,D0,D1,D2,D3> ret;
@@ -1321,7 +1321,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()!=T2()),N,D0,D1,D2,D3>
     operator!=( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()!=T2()),N,D0,D1,D2,D3> ret;
@@ -1353,7 +1353,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()&&T2()),N,D0,D1,D2,D3>
     operator&&( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()&&T2()),N,D0,D1,D2,D3> ret;
@@ -1385,7 +1385,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, class T2, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()||T2()),N,D0,D1,D2,D3>
     operator||( SArray<T1,N,D0,D1,D2,D3> const &left , SArray<T2,N,D0,D1,D2,D3> const &right ) {
       SArray<decltype(T1()||T2()),N,D0,D1,D2,D3> ret;
@@ -1421,7 +1421,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(!T1()),N,D0,D1,D2,D3>
     operator!( SArray<T1,N,D0,D1,D2,D3> const &left ) {
       SArray<decltype(!T1()),N,D0,D1,D2,D3> ret;
@@ -1453,7 +1453,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()+1),N,D0,D1,D2,D3>
     operator++( SArray<T1,N,D0,D1,D2,D3> const &left ) {
       SArray<decltype(T1()+1),N,D0,D1,D2,D3> ret;
@@ -1485,7 +1485,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()+1),N,D0,D1,D2,D3>
     operator++( SArray<T1,N,D0,D1,D2,D3> const &left , int dummy) {
       SArray<decltype(T1()+1),N,D0,D1,D2,D3> ret;
@@ -1517,7 +1517,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()-1),N,D0,D1,D2,D3>
     operator--( SArray<T1,N,D0,D1,D2,D3> const &left ) {
       SArray<decltype(T1()-1),N,D0,D1,D2,D3> ret;
@@ -1549,7 +1549,7 @@ namespace yakl {
       if constexpr (streams_enabled) fence();
       return ret;
     }
-    template <class T1, int N, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, int N, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()-1),N,D0,D1,D2,D3>
     operator--( SArray<T1,N,D0,D1,D2,D3> const &left , int dummy ) {
       SArray<decltype(T1()-1),N,D0,D1,D2,D3> ret;

--- a/src/extensions/YAKL_pentadiagonal.h
+++ b/src/extensions/YAKL_pentadiagonal.h
@@ -10,7 +10,7 @@ namespace yakl {
 
 
   /** @private */
-  template <unsigned int n, class real>
+  template <index_t n, class real>
   YAKL_INLINE real penta_sum(SArray<real,1,n> const &v, SArray<real,1,n> const &z) {
     real sum = 0;
     for (int k=0; k < n; k++) {
@@ -22,7 +22,7 @@ namespace yakl {
 
 
   /** @private */
-  template <unsigned int n, class real>
+  template <index_t n, class real>
   YAKL_INLINE void matrix_inverse_small(SArray<real,2,n,n> &a) {
     SArray<real,2,n,n> inv;
 
@@ -92,7 +92,7 @@ namespace yakl {
    * ```
    * input are the a, b, c, d, e, and f and they are not modified
    */
-  template <unsigned int n, class real>
+  template <index_t n, class real>
   YAKL_INLINE void pentadiagonal(SArray<real,1,n> const &a,
                                  SArray<real,1,n> const &b,
                                  SArray<real,1,n> const &c,
@@ -149,7 +149,7 @@ namespace yakl {
    * ```
    * input are the a, b, c, d, e, and f and they are not modified
    */
-  template <unsigned int n, class real>
+  template <index_t n, class real>
   YAKL_INLINE void pentadiagonal_periodic(SArray<real,1,n> const &a,
                                           SArray<real,1,n> const &b,
                                           SArray<real,1,n> const &c,

--- a/src/extensions/YAKL_simd.h
+++ b/src/extensions/YAKL_simd.h
@@ -36,14 +36,14 @@ namespace simd {
     * Whenever different behavior is needed for different members of the Pack object (e.g., if-statement),
     * the user must iterate explicitly over the pack with yakl::iterate_over_pack.
     */
-  template <class T, int N>
+  template <class T, index_t N>
   class Pack {
   public:
     /** @private */
     T myData[N];
 
     /** @brief Returns a modifiable reference to the data at the requested index */
-    YAKL_INLINE T & operator() (int i) {
+    YAKL_INLINE T & operator() (index_t i) {
       #ifdef YAKL_DEBUG
         if (i >= N) { yakl_throw("Pack index out of bounds"); }
       #endif
@@ -51,7 +51,7 @@ namespace simd {
     }
 
     /** @brief Returns a non-modifiable value to the data at the requested index */
-    YAKL_INLINE T operator() (int i) const {
+    YAKL_INLINE T operator() (index_t i) const {
       #ifdef YAKL_DEBUG
         if (i >= N) { yakl_throw("Pack index out of bounds"); }
       #endif
@@ -59,7 +59,7 @@ namespace simd {
     }
 
     /** @brief Returns the number of elements in the Pack object */
-    YAKL_INLINE static int constexpr get_pack_size() { return N; }
+    YAKL_INLINE static index_t constexpr get_pack_size() { return N; }
 
     //////////////////////////////////////
     // SELF OPERATORS WITH SCALAR VALUES
@@ -67,35 +67,35 @@ namespace simd {
     template <class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
     YAKL_INLINE Pack<T,N> & operator= (TLOC rhs) {
       GET_SIMD_PRAGMA()
-      for (int i=0 ; i < N ; i++) { (*this)(i) = rhs; }
+      for (index_t i=0 ; i < N ; i++) { (*this)(i) = rhs; }
       return *this;
     }
 
     template <class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
     YAKL_INLINE Pack<T,N> & operator+= (TLOC rhs) {
       GET_SIMD_PRAGMA()
-      for (int i=0; i < N; i++) { (*this)(i) += rhs; }
+      for (index_t i=0; i < N; i++) { (*this)(i) += rhs; }
       return *this;
     }
 
     template <class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
     YAKL_INLINE Pack<T,N> & operator-= (TLOC rhs) {
       GET_SIMD_PRAGMA()
-      for (int i=0; i < N; i++) { (*this)(i) -= rhs; }
+      for (index_t i=0; i < N; i++) { (*this)(i) -= rhs; }
       return *this;
     }
 
     template <class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
     YAKL_INLINE Pack<T,N> & operator*= (TLOC rhs) {
       GET_SIMD_PRAGMA()
-      for (int i=0; i < N; i++) { (*this)(i) *= rhs; }
+      for (index_t i=0; i < N; i++) { (*this)(i) *= rhs; }
       return *this;
     }
 
     template <class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
     YAKL_INLINE Pack<T,N> & operator/= (TLOC rhs) {
       GET_SIMD_PRAGMA()
-      for (int i=0; i < N; i++) { (*this)(i) /= rhs; }
+      for (index_t i=0; i < N; i++) { (*this)(i) /= rhs; }
       return *this;
     }
 
@@ -105,35 +105,35 @@ namespace simd {
     template <class TLOC>
     YAKL_INLINE Pack<T,N> & operator+= (Pack<TLOC,N> rhs) {
       GET_SIMD_PRAGMA()
-      for (int i=0; i < N; i++) { (*this)(i) += rhs(i); }
+      for (index_t i=0; i < N; i++) { (*this)(i) += rhs(i); }
       return *this;
     }
 
     template <class TLOC>
     YAKL_INLINE Pack<T,N> & operator-= (Pack<TLOC,N> rhs) {
       GET_SIMD_PRAGMA()
-      for (int i=0; i < N; i++) { (*this)(i) -= rhs(i); }
+      for (index_t i=0; i < N; i++) { (*this)(i) -= rhs(i); }
       return *this;
     }
 
     template <class TLOC>
     YAKL_INLINE Pack<T,N> & operator*= (Pack<TLOC,N> rhs) {
       GET_SIMD_PRAGMA()
-      for (int i=0; i < N; i++) { (*this)(i) *= rhs(i); }
+      for (index_t i=0; i < N; i++) { (*this)(i) *= rhs(i); }
       return *this;
     }
 
     template <class TLOC>
     YAKL_INLINE Pack<T,N> & operator/= (Pack<TLOC,N> rhs) {
       GET_SIMD_PRAGMA()
-      for (int i=0; i < N; i++) { (*this)(i) /= rhs(i); }
+      for (index_t i=0; i < N; i++) { (*this)(i) /= rhs(i); }
       return *this;
     }
 
 
     /** @brief Print out the Pack object values to stdout. */
     inline friend std::ostream &operator<<(std::ostream& os, Pack<T,N> const &v) {
-      for (int i=0; i<N; i++) { os << std::setw(12) << v(i) << "  "; }
+      for (index_t i=0; i<N; i++) { os << std::setw(12) << v(i) << "  "; }
       os << "\n";
       return os;
     }
@@ -146,7 +146,7 @@ namespace simd {
    * @param N    Number of elements in the Pack(s) being used inside iterate_over_pack
    * @param SIMD Whether the functor passed to iterate_over_pack is parallelizeable or not
    */
-  template <int N, bool SIMD=false> struct PackIterConfig {};
+  template <index_t N, bool SIMD=false> struct PackIterConfig {};
 
 
 
@@ -160,13 +160,13 @@ namespace simd {
    *               to loop over; and (2) a bool SIMD parameter to tell this routine whether or not it should apply a
    *               SIMD pragma.
    */
-  template <class F, int N, bool SIMD=false>
+  template <class F, index_t N, bool SIMD=false>
   YAKL_INLINE void iterate_over_pack( F const &f , PackIterConfig<N,SIMD> config ) {
     if constexpr (SIMD) {
       GET_SIMD_PRAGMA()
-      for (int i=0 ; i < N ; i++) { f(i); }
+      for (index_t i=0 ; i < N ; i++) { f(i); }
     } else {
-      for (int i=0 ; i < N ; i++) { f(i); }
+      for (index_t i=0 ; i < N ; i++) { f(i); }
     }
   }
 
@@ -174,71 +174,71 @@ namespace simd {
   //////////////////////////////////////////////////////////////
   // OPERATIONS WITH SCALARS
   //////////////////////////////////////////////////////////////
-  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, index_t N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator+ (Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = lhs(i) + val; }
+    for (index_t i=0; i < N; i++) { ret(i) = lhs(i) + val; }
     return ret;
   }
-  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, index_t N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator+ (TLOC val , Pack<T,N> rhs) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = val + rhs(i); }
+    for (index_t i=0; i < N; i++) { ret(i) = val + rhs(i); }
     return ret;
   }
 
-  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, index_t N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator- (Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = lhs(i) - val; }
+    for (index_t i=0; i < N; i++) { ret(i) = lhs(i) - val; }
     return ret;
   }
-  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, index_t N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator- (TLOC val , Pack<T,N> rhs) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = val - rhs(i); }
+    for (index_t i=0; i < N; i++) { ret(i) = val - rhs(i); }
     return ret;
   }
 
-  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, index_t N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator* (Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = lhs(i) * val; }
+    for (index_t i=0; i < N; i++) { ret(i) = lhs(i) * val; }
     return ret;
   }
-  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, index_t N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator* (TLOC val , Pack<T,N> rhs) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = val * rhs(i); }
+    for (index_t i=0; i < N; i++) { ret(i) = val * rhs(i); }
     return ret;
   }
 
-  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, index_t N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator/ (Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = lhs(i) / val; }
+    for (index_t i=0; i < N; i++) { ret(i) = lhs(i) / val; }
     return ret;
   }
-  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, index_t N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator/ (TLOC val , Pack<T,N> rhs) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = val / rhs(i); }
+    for (index_t i=0; i < N; i++) { ret(i) = val / rhs(i); }
     return ret;
   }
 
-  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, index_t N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> pow(Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::pow( lhs(i) , val ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::pow( lhs(i) , val ); }
     return ret;
   }
 
@@ -246,123 +246,123 @@ namespace simd {
   //////////////////////////////////////////////////////////////
   // UNARY OPERATORS
   //////////////////////////////////////////////////////////////
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> operator- ( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = -( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = -( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> sqrt( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::sqrt( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::sqrt( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> abs( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::abs( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::abs( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> exp( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::exp( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::exp( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> log( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::log( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::log( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> log10( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::log10( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::log10( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> cos( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::cos( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::cos( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> sin( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::sin( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::sin( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> tan( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::tan( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::tan( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> acos( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::acos( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::acos( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> asin( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::asin( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::asin( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> atan( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::atan( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::atan( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> ceil( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::ceil( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::ceil( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> floor( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::floor( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::floor( a(i) ); }
     return ret;
   }
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> round( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) { ret(i) = std::round( a(i) ); }
+    for (index_t i=0; i < N; i++) { ret(i) = std::round( a(i) ); }
     return ret;
   }
 
@@ -371,55 +371,55 @@ namespace simd {
   //////////////////////////////////////////////////////////////
   // BINARY OPERATORS
   //////////////////////////////////////////////////////////////
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> operator+( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) {
+    for (index_t i=0; i < N; i++) {
       ret(i) = a(i) + b(i);
     }
     return ret;
   }
 
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> operator-( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) {
+    for (index_t i=0; i < N; i++) {
       ret(i) = a(i) - b(i);
     }
     return ret;
   }
 
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> operator*( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) {
+    for (index_t i=0; i < N; i++) {
       ret(i) = a(i) * b(i);
     }
     return ret;
   }
 
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> operator/( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) {
+    for (index_t i=0; i < N; i++) {
       ret(i) = a(i) / b(i);
     }
     return ret;
   }
 
 
-  template <class T, int N>
+  template <class T, index_t N>
   YAKL_INLINE Pack<T,N> pow( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (int i=0; i < N; i++) {
+    for (index_t i=0; i < N; i++) {
       ret(i) = std::pow( a(i) , b(i) );
     }
     return ret;

--- a/src/extensions/YAKL_simd.h
+++ b/src/extensions/YAKL_simd.h
@@ -36,14 +36,14 @@ namespace simd {
     * Whenever different behavior is needed for different members of the Pack object (e.g., if-statement),
     * the user must iterate explicitly over the pack with yakl::iterate_over_pack.
     */
-  template <class T, unsigned int N>
+  template <class T, int N>
   class Pack {
   public:
     /** @private */
     T myData[N];
 
     /** @brief Returns a modifiable reference to the data at the requested index */
-    YAKL_INLINE T & operator() (uint i) {
+    YAKL_INLINE T & operator() (int i) {
       #ifdef YAKL_DEBUG
         if (i >= N) { yakl_throw("Pack index out of bounds"); }
       #endif
@@ -51,7 +51,7 @@ namespace simd {
     }
 
     /** @brief Returns a non-modifiable value to the data at the requested index */
-    YAKL_INLINE T operator() (uint i) const {
+    YAKL_INLINE T operator() (int i) const {
       #ifdef YAKL_DEBUG
         if (i >= N) { yakl_throw("Pack index out of bounds"); }
       #endif
@@ -74,28 +74,28 @@ namespace simd {
     template <class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
     YAKL_INLINE Pack<T,N> & operator+= (TLOC rhs) {
       GET_SIMD_PRAGMA()
-      for (uint i=0; i < N; i++) { (*this)(i) += rhs; }
+      for (int i=0; i < N; i++) { (*this)(i) += rhs; }
       return *this;
     }
 
     template <class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
     YAKL_INLINE Pack<T,N> & operator-= (TLOC rhs) {
       GET_SIMD_PRAGMA()
-      for (uint i=0; i < N; i++) { (*this)(i) -= rhs; }
+      for (int i=0; i < N; i++) { (*this)(i) -= rhs; }
       return *this;
     }
 
     template <class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
     YAKL_INLINE Pack<T,N> & operator*= (TLOC rhs) {
       GET_SIMD_PRAGMA()
-      for (uint i=0; i < N; i++) { (*this)(i) *= rhs; }
+      for (int i=0; i < N; i++) { (*this)(i) *= rhs; }
       return *this;
     }
 
     template <class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
     YAKL_INLINE Pack<T,N> & operator/= (TLOC rhs) {
       GET_SIMD_PRAGMA()
-      for (uint i=0; i < N; i++) { (*this)(i) /= rhs; }
+      for (int i=0; i < N; i++) { (*this)(i) /= rhs; }
       return *this;
     }
 
@@ -105,35 +105,35 @@ namespace simd {
     template <class TLOC>
     YAKL_INLINE Pack<T,N> & operator+= (Pack<TLOC,N> rhs) {
       GET_SIMD_PRAGMA()
-      for (uint i=0; i < N; i++) { (*this)(i) += rhs(i); }
+      for (int i=0; i < N; i++) { (*this)(i) += rhs(i); }
       return *this;
     }
 
     template <class TLOC>
     YAKL_INLINE Pack<T,N> & operator-= (Pack<TLOC,N> rhs) {
       GET_SIMD_PRAGMA()
-      for (uint i=0; i < N; i++) { (*this)(i) -= rhs(i); }
+      for (int i=0; i < N; i++) { (*this)(i) -= rhs(i); }
       return *this;
     }
 
     template <class TLOC>
     YAKL_INLINE Pack<T,N> & operator*= (Pack<TLOC,N> rhs) {
       GET_SIMD_PRAGMA()
-      for (uint i=0; i < N; i++) { (*this)(i) *= rhs(i); }
+      for (int i=0; i < N; i++) { (*this)(i) *= rhs(i); }
       return *this;
     }
 
     template <class TLOC>
     YAKL_INLINE Pack<T,N> & operator/= (Pack<TLOC,N> rhs) {
       GET_SIMD_PRAGMA()
-      for (uint i=0; i < N; i++) { (*this)(i) /= rhs(i); }
+      for (int i=0; i < N; i++) { (*this)(i) /= rhs(i); }
       return *this;
     }
 
 
     /** @brief Print out the Pack object values to stdout. */
     inline friend std::ostream &operator<<(std::ostream& os, Pack<T,N> const &v) {
-      for (uint i=0; i<N; i++) { os << std::setw(12) << v(i) << "  "; }
+      for (int i=0; i<N; i++) { os << std::setw(12) << v(i) << "  "; }
       os << "\n";
       return os;
     }
@@ -146,7 +146,7 @@ namespace simd {
    * @param N    Number of elements in the Pack(s) being used inside iterate_over_pack
    * @param SIMD Whether the functor passed to iterate_over_pack is parallelizeable or not
    */
-  template <unsigned int N, bool SIMD=false> struct PackIterConfig {};
+  template <int N, bool SIMD=false> struct PackIterConfig {};
 
 
 
@@ -160,7 +160,7 @@ namespace simd {
    *               to loop over; and (2) a bool SIMD parameter to tell this routine whether or not it should apply a
    *               SIMD pragma.
    */
-  template <class F, unsigned int N, bool SIMD=false>
+  template <class F, int N, bool SIMD=false>
   YAKL_INLINE void iterate_over_pack( F const &f , PackIterConfig<N,SIMD> config ) {
     if constexpr (SIMD) {
       GET_SIMD_PRAGMA()
@@ -174,71 +174,71 @@ namespace simd {
   //////////////////////////////////////////////////////////////
   // OPERATIONS WITH SCALARS
   //////////////////////////////////////////////////////////////
-  template <class T, unsigned int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator+ (Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (uint i=0; i < N; i++) { ret(i) = lhs(i) + val; }
+    for (int i=0; i < N; i++) { ret(i) = lhs(i) + val; }
     return ret;
   }
-  template <class T, unsigned int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator+ (TLOC val , Pack<T,N> rhs) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (uint i=0; i < N; i++) { ret(i) = val + rhs(i); }
+    for (int i=0; i < N; i++) { ret(i) = val + rhs(i); }
     return ret;
   }
 
-  template <class T, unsigned int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator- (Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (uint i=0; i < N; i++) { ret(i) = lhs(i) - val; }
+    for (int i=0; i < N; i++) { ret(i) = lhs(i) - val; }
     return ret;
   }
-  template <class T, unsigned int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator- (TLOC val , Pack<T,N> rhs) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (uint i=0; i < N; i++) { ret(i) = val - rhs(i); }
+    for (int i=0; i < N; i++) { ret(i) = val - rhs(i); }
     return ret;
   }
 
-  template <class T, unsigned int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator* (Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (uint i=0; i < N; i++) { ret(i) = lhs(i) * val; }
+    for (int i=0; i < N; i++) { ret(i) = lhs(i) * val; }
     return ret;
   }
-  template <class T, unsigned int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator* (TLOC val , Pack<T,N> rhs) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (uint i=0; i < N; i++) { ret(i) = val * rhs(i); }
+    for (int i=0; i < N; i++) { ret(i) = val * rhs(i); }
     return ret;
   }
 
-  template <class T, unsigned int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator/ (Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (uint i=0; i < N; i++) { ret(i) = lhs(i) / val; }
+    for (int i=0; i < N; i++) { ret(i) = lhs(i) / val; }
     return ret;
   }
-  template <class T, unsigned int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> operator/ (TLOC val , Pack<T,N> rhs) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (uint i=0; i < N; i++) { ret(i) = val / rhs(i); }
+    for (int i=0; i < N; i++) { ret(i) = val / rhs(i); }
     return ret;
   }
 
-  template <class T, unsigned int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
+  template <class T, int N, class TLOC , typename std::enable_if<std::is_arithmetic<TLOC>::value,bool>::type = false >
   YAKL_INLINE Pack<T,N> pow(Pack<T,N> lhs , TLOC val) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
-    for (uint i=0; i < N; i++) { ret(i) = std::pow( lhs(i) , val ); }
+    for (int i=0; i < N; i++) { ret(i) = std::pow( lhs(i) , val ); }
     return ret;
   }
 
@@ -246,7 +246,7 @@ namespace simd {
   //////////////////////////////////////////////////////////////
   // UNARY OPERATORS
   //////////////////////////////////////////////////////////////
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> operator- ( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -254,7 +254,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> sqrt( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -262,7 +262,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> abs( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -270,7 +270,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> exp( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -278,7 +278,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> log( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -286,7 +286,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> log10( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -294,7 +294,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> cos( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -302,7 +302,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> sin( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -310,7 +310,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> tan( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -318,7 +318,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> acos( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -326,7 +326,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> asin( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -334,7 +334,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> atan( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -342,7 +342,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> ceil( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -350,7 +350,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> floor( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -358,7 +358,7 @@ namespace simd {
     return ret;
   }
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> round( Pack<T,N> a ) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -371,7 +371,7 @@ namespace simd {
   //////////////////////////////////////////////////////////////
   // BINARY OPERATORS
   //////////////////////////////////////////////////////////////
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> operator+( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -382,7 +382,7 @@ namespace simd {
   }
 
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> operator-( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -393,7 +393,7 @@ namespace simd {
   }
 
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> operator*( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -404,7 +404,7 @@ namespace simd {
   }
 
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> operator/( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()
@@ -415,7 +415,7 @@ namespace simd {
   }
 
 
-  template <class T, unsigned int N>
+  template <class T, int N>
   YAKL_INLINE Pack<T,N> pow( Pack<T,N> a , Pack<T,N> b) {
     Pack<T,N> ret;
     GET_SIMD_PRAGMA()

--- a/src/extensions/YAKL_tridiagonal.h
+++ b/src/extensions/YAKL_tridiagonal.h
@@ -47,7 +47,7 @@ namespace yakl {
    * ```
    * Unfortunately, periodic boundary conditions roughly double the amount of work in the tridiagonal solve
    */
-  template <class real, unsigned int n>
+  template <class real, index_t n>
   YAKL_INLINE void tridiagonal_periodic(SArray<real,1,n> const &a, SArray<real,1,n> &b, SArray<real,1,n> &c, SArray<real,1,n> &d) {
     SArray<real,1,n> tmp;
     // Save the original "b0" because it's needed later on to compute ( (v^T*y) / (1 + v^T*q) )
@@ -115,7 +115,7 @@ namespace yakl {
    * 
    * This uses the Thomas algorithm.
   */
-  template <class real, unsigned int n>
+  template <class real, index_t n>
   YAKL_INLINE void tridiagonal(SArray<real,1,n> const &a, SArray<real,1,n> const &b, SArray<real,1,n> &c, SArray<real,1,n> &d) {
     real tmp = static_cast<real>(1) / b(0);
     c(0) *= tmp;

--- a/src/extensions/intrinsics/YAKL_intrinsics_abs.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_abs.h
@@ -28,7 +28,7 @@ namespace yakl {
       return ret;
     }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<T,rank,D0,D1,D2,D3> abs( SArray<T,rank,D0,D1,D2,D3> const &arr ) {
       SArray<T,rank,D0,D1,D2,D3> ret;
       for (int i=0; i < ret.totElems(); i++) { ret.data()[i] = std::abs(arr.data()[i]); };

--- a/src/extensions/intrinsics/YAKL_intrinsics_all.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_all.h
@@ -27,7 +27,7 @@ namespace yakl {
       return all_true.hostRead(stream);
     }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     inline bool all( SArray<T,rank,D0,D1,D2,D3> const &arr ) {
       bool all_true = true;
       for (int i=0; i < arr.totElems(); i++) { if (!arr.data()[i]) all_true = false; }

--- a/src/extensions/intrinsics/YAKL_intrinsics_any.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_any.h
@@ -27,7 +27,7 @@ namespace yakl {
       return any_true.hostRead(stream);
     }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     inline bool any( SArray<T,rank,D0,D1,D2,D3> const &arr ) {
       bool any_true = false;
       for (int i=0; i < arr.totElems(); i++) { if (arr.data()[i]) any_true = true; }

--- a/src/extensions/intrinsics/YAKL_intrinsics_count.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_count.h
@@ -38,7 +38,7 @@ namespace yakl {
       return numTrue;
     }
 
-    template <int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE int count( SArray<bool,rank,D0,D1,D2,D3> const &mask ) {
       int numTrue = 0;
       for (int i=0; i < mask.totElems(); i++) {

--- a/src/extensions/intrinsics/YAKL_intrinsics_epsilon.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_epsilon.h
@@ -14,7 +14,7 @@ namespace yakl {
     template <class T, int rank, class D0, class D1, class D2, class D3>
     YAKL_INLINE T constexpr epsilon(FSArray<T,rank,D0,D1,D2,D3> const &arr) { return std::numeric_limits<T>::epsilon(); }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE T constexpr epsilon(SArray<T,rank,D0,D1,D2,D3> const &arr) { return std::numeric_limits<T>::epsilon(); }
 
   }

--- a/src/extensions/intrinsics/YAKL_intrinsics_huge.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_huge.h
@@ -14,7 +14,7 @@ namespace yakl {
     template <class T, int rank, class D0, class D1, class D2, class D3>
     YAKL_INLINE T constexpr huge(FSArray<T,rank,D0,D1,D2,D3> const &arr) { return std::numeric_limits<T>::max(); }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE T constexpr huge(SArray<T,rank,D0,D1,D2,D3> const &arr) { return std::numeric_limits<T>::max(); }
 
   }

--- a/src/extensions/intrinsics/YAKL_intrinsics_matinv.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_matinv.h
@@ -6,7 +6,7 @@ __YAKL_NAMESPACE_WRAPPER_BEGIN__
 namespace yakl {
   namespace intrinsics {
 
-    template <unsigned int n, class real>
+    template <index_t n, class real>
     YAKL_INLINE SArray<real,2,n,n> matinv_ge(SArray<real,2,n,n> const &a) {
       SArray<real,2,n,n> scratch;
       SArray<real,2,n,n> inv;

--- a/src/extensions/intrinsics/YAKL_intrinsics_matmul.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_matmul.h
@@ -9,7 +9,7 @@ namespace yakl {
     ///////////////////////////////////////////////////////////
     // Matrix multiplication routines for column-row format
     ///////////////////////////////////////////////////////////
-    template <class T, index_t COL_L, index_t ROW_L, index_t COL_R>
+    template <class T, unsigned COL_L, unsigned ROW_L, unsigned COL_R>
     YAKL_INLINE SArray<T,2,COL_R,ROW_L>
     matmul_cr ( SArray<T,2,COL_L,ROW_L> const &left ,
                 SArray<T,2,COL_R,COL_L> const &right ) {
@@ -26,7 +26,7 @@ namespace yakl {
       return ret;
     }
 
-    template<class T, index_t COL_L, index_t ROW_L>
+    template<class T, unsigned COL_L, unsigned ROW_L>
     YAKL_INLINE SArray<T,1,ROW_L>
     matmul_cr ( SArray<T,2,COL_L,ROW_L> const &left ,
                 SArray<T,1,COL_L>       const &right ) {
@@ -77,7 +77,7 @@ namespace yakl {
     ///////////////////////////////////////////////////////////
     // Matrix multiplication routines for row-column format
     ///////////////////////////////////////////////////////////
-    template <class T, index_t COL_L, index_t ROW_L, index_t COL_R>
+    template <class T, unsigned COL_L, unsigned ROW_L, unsigned COL_R>
     YAKL_INLINE SArray<T,2,ROW_L,COL_R>
     matmul_rc ( SArray<T,2,ROW_L,COL_L> const &left ,
                 SArray<T,2,COL_L,COL_R> const &right ) {
@@ -94,7 +94,7 @@ namespace yakl {
       return ret;
     }
 
-    template<class T, index_t COL_L, index_t ROW_L>
+    template<class T, unsigned COL_L, unsigned ROW_L>
     YAKL_INLINE SArray<T,1,ROW_L>
     matmul_rc ( SArray<T,2,ROW_L,COL_L> const &left ,
                 SArray<T,1,COL_L>       const &right ) {

--- a/src/extensions/intrinsics/YAKL_intrinsics_matmul.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_matmul.h
@@ -9,7 +9,7 @@ namespace yakl {
     ///////////////////////////////////////////////////////////
     // Matrix multiplication routines for column-row format
     ///////////////////////////////////////////////////////////
-    template <class T, unsigned COL_L, unsigned ROW_L, unsigned COL_R>
+    template <class T, index_t COL_L, index_t ROW_L, index_t COL_R>
     YAKL_INLINE SArray<T,2,COL_R,ROW_L>
     matmul_cr ( SArray<T,2,COL_L,ROW_L> const &left ,
                 SArray<T,2,COL_R,COL_L> const &right ) {
@@ -26,7 +26,7 @@ namespace yakl {
       return ret;
     }
 
-    template<class T, unsigned COL_L, unsigned ROW_L>
+    template<class T, index_t COL_L, index_t ROW_L>
     YAKL_INLINE SArray<T,1,ROW_L>
     matmul_cr ( SArray<T,2,COL_L,ROW_L> const &left ,
                 SArray<T,1,COL_L>       const &right ) {
@@ -77,7 +77,7 @@ namespace yakl {
     ///////////////////////////////////////////////////////////
     // Matrix multiplication routines for row-column format
     ///////////////////////////////////////////////////////////
-    template <class T, unsigned COL_L, unsigned ROW_L, unsigned COL_R>
+    template <class T, index_t COL_L, index_t ROW_L, index_t COL_R>
     YAKL_INLINE SArray<T,2,ROW_L,COL_R>
     matmul_rc ( SArray<T,2,ROW_L,COL_L> const &left ,
                 SArray<T,2,COL_L,COL_R> const &right ) {
@@ -94,7 +94,7 @@ namespace yakl {
       return ret;
     }
 
-    template<class T, unsigned COL_L, unsigned ROW_L>
+    template<class T, index_t COL_L, index_t ROW_L>
     YAKL_INLINE SArray<T,1,ROW_L>
     matmul_rc ( SArray<T,2,ROW_L,COL_L> const &left ,
                 SArray<T,1,COL_L>       const &right ) {

--- a/src/extensions/intrinsics/YAKL_intrinsics_maxloc.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_maxloc.h
@@ -67,7 +67,7 @@ namespace yakl {
       return loc;
     }
 
-    template <class T, unsigned D0>
+    template <class T, index_t D0>
     YAKL_INLINE int maxloc( SArray<T,1,D0> const &arr ) {
       T m = arr.data()[0];
       int loc = 0;

--- a/src/extensions/intrinsics/YAKL_intrinsics_maxval.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_maxval.h
@@ -37,7 +37,7 @@ namespace yakl {
       return m;
     }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE T maxval( SArray<T,rank,D0,D1,D2,D3> const &arr ) {
       typename std::remove_cv<T>::type m = arr.data()[0];
       for (int i=1; i<arr.totElems(); i++) {

--- a/src/extensions/intrinsics/YAKL_intrinsics_merge.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_merge.h
@@ -26,7 +26,7 @@ namespace yakl {
           yakl_throw("ERROR: calling merge with array shapes that do not match");
       #endif
       Array<decltype(T1()+T2()),rank,memHost,myStyle> ret = arr_true.createHostObject();
-      for (unsigned i=0; i < arr_true.totElems(); i++) {
+      for (index_t i=0; i < arr_true.totElems(); i++) {
         ret.data()[i] = mask.data()[i] ? arr_true.data()[i] : arr_false.data()[i];
       }
       return ret;
@@ -55,13 +55,13 @@ namespace yakl {
       return ret;
     }
 
-    template <class T1, class T2, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<decltype(T1()+T2()),rank,D0,D1,D2,D3>
     merge( SArray<T1  ,rank,D0,D1,D2,D3> const & arr_true  ,
            SArray<T2  ,rank,D0,D1,D2,D3> const & arr_false ,
            SArray<bool,rank,D0,D1,D2,D3> const & mask      ) {
       SArray<decltype(T1()+T2()),rank,D0,D1,D2,D3> ret;
-      for (unsigned i=0; i < arr_true.totElems(); i++) {
+      for (index_t i=0; i < arr_true.totElems(); i++) {
         ret.data()[i] = mask.data()[i] ? arr_true.data()[i] : arr_false.data()[i];
       }
       return ret;
@@ -73,7 +73,7 @@ namespace yakl {
            FSArray<T2  ,rank,B0,B1,B2,B3> const & arr_false ,
            FSArray<bool,rank,B0,B1,B2,B3> const & mask      ) {
       FSArray<decltype(T1()+T2()),rank,B0,B1,B2,B3> ret;
-      for (unsigned i=0; i < arr_true.totElems(); i++) {
+      for (index_t i=0; i < arr_true.totElems(); i++) {
         ret.data()[i] = mask.data()[i] ? arr_true.data()[i] : arr_false.data()[i];
       }
       return ret;

--- a/src/extensions/intrinsics/YAKL_intrinsics_minloc.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_minloc.h
@@ -67,7 +67,7 @@ namespace yakl {
       return loc;
     }
 
-    template <class T, unsigned D0>
+    template <class T, index_t D0>
     YAKL_INLINE int minloc( SArray<T,1,D0> const &arr ) {
       T m = arr.data()[0];
       int loc = 0;

--- a/src/extensions/intrinsics/YAKL_intrinsics_minval.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_minval.h
@@ -37,7 +37,7 @@ namespace yakl {
       return m;
     }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE T minval( SArray<T,rank,D0,D1,D2,D3> const &arr ) {
       typename std::remove_cv<T>::type m = arr.data()[0];
       for (int i=1; i<arr.totElems(); i++) {

--- a/src/extensions/intrinsics/YAKL_intrinsics_product.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_product.h
@@ -33,7 +33,7 @@ namespace yakl {
       return m;
     }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE T product( SArray<T,rank,D0,D1,D2,D3> const &arr ) {
       T m = arr.data()[0];
       for (int i=1; i<arr.totElems(); i++) { m *= arr.data()[i]; }

--- a/src/extensions/intrinsics/YAKL_intrinsics_sign.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_sign.h
@@ -44,7 +44,7 @@ namespace yakl {
       return ret;
     }
 
-    template <class T1, class T2, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T1, class T2, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE SArray<T1,rank,D0,D1,D2,D3> sign( SArray<T1,rank,D0,D1,D2,D3> const & a ,
                                                   SArray<T2,rank,D0,D1,D2,D3> const & b ) {
       SArray<T1,rank,D0,D1,D2,D3> ret;

--- a/src/extensions/intrinsics/YAKL_intrinsics_sum.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_sum.h
@@ -33,7 +33,7 @@ namespace yakl {
       return m;
     }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE T sum( SArray<T,rank,D0,D1,D2,D3> const &arr ) {
       typename std::remove_cv<T>::type m = arr.data()[0];
       for (int i=1; i<arr.totElems(); i++) { m += arr.data()[i]; }

--- a/src/extensions/intrinsics/YAKL_intrinsics_tiny.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_tiny.h
@@ -14,7 +14,7 @@ namespace yakl {
     template <class T, int rank, class D0, class D1, class D2, class D3>
     YAKL_INLINE T constexpr tiny(FSArray<T,rank,D0,D1,D2,D3> const &arr) { return std::numeric_limits<T>::min(); }
 
-    template <class T, int rank, unsigned D0, unsigned D1, unsigned D2, unsigned D3>
+    template <class T, int rank, index_t D0, index_t D1, index_t D2, index_t D3>
     YAKL_INLINE T constexpr tiny(SArray<T,rank,D0,D1,D2,D3> const &arr) { return std::numeric_limits<T>::min(); }
 
   }

--- a/src/extensions/intrinsics/YAKL_intrinsics_transpose.h
+++ b/src/extensions/intrinsics/YAKL_intrinsics_transpose.h
@@ -58,7 +58,7 @@ namespace yakl {
       }
     }
 
-    template <unsigned int n1, unsigned int n2, class T>
+    template <index_t n1, index_t n2, class T>
     YAKL_INLINE SArray<T,2,n2,n1> transpose(SArray<T,2,n1,n2> const &a) {
       SArray<T,2,n2,n1> ret;
       for (int j=0; j < n1; j++) {

--- a/unit/build/machines/thatchroof/thatchroof_gpu.sh
+++ b/unit/build/machines/thatchroof/thatchroof_gpu.sh
@@ -2,7 +2,7 @@
 
 source /usr/share/modules/init/bash
 module purge
-
+module load cmake-3.23.2-gcc-11.1.0-kvgnqc6 netcdf-c-4.9.2-gcc-11.1.0-mvu6i6y
 
 ../../cmakeclean.sh
 

--- a/unit/build/machines/thatchroof/thatchroof_gpu_debug.sh
+++ b/unit/build/machines/thatchroof/thatchroof_gpu_debug.sh
@@ -2,7 +2,7 @@
 
 source /usr/share/modules/init/bash
 module purge
-module load cmake-3.23.2-gcc-11.1.0-kvgnqc6
+module load cmake-3.23.2-gcc-11.1.0-kvgnqc6 netcdf-c-4.9.2-gcc-11.1.0-mvu6i6y
 
 ../../cmakeclean.sh
 

--- a/unit/build/machines/thatchroof/thatchroof_gpu_debug_nvc++.sh
+++ b/unit/build/machines/thatchroof/thatchroof_gpu_debug_nvc++.sh
@@ -2,7 +2,7 @@
 
 source /usr/share/modules/init/bash
 module purge
-module load cmake-3.23.2-gcc-11.1.0-kvgnqc6 nvhpc-23.3-gcc-11.1.0-lyprlux
+module load cmake-3.23.2-gcc-11.1.0-kvgnqc6 nvhpc-23.3-gcc-11.1.0-lyprlux netcdf-c-4.9.2-nvhpc-23.3-l7riqnm
 
 ../../cmakeclean.sh
 

--- a/unit/build/machines/thatchroof/thatchroof_gpu_nvc++.sh
+++ b/unit/build/machines/thatchroof/thatchroof_gpu_nvc++.sh
@@ -2,7 +2,7 @@
 
 source /usr/share/modules/init/bash
 module purge
-module load cmake-3.23.2-gcc-11.1.0-kvgnqc6 nvhpc-23.3-gcc-11.1.0-lyprlux
+module load cmake-3.23.2-gcc-11.1.0-kvgnqc6 nvhpc-23.3-gcc-11.1.0-lyprlux netcdf-c-4.9.2-nvhpc-23.3-l7riqnm
 
 ../../cmakeclean.sh
 


### PR DESCRIPTION
This PR changes loop indexing from unsigned int to size_t by changing YAKL's `index_t` typedef to size_t, and changing YAKL_CSArray to use the same. YAKL_simd is also changed to use int instead of unsigned int because Pack size will never be large enough to need something like index_t. Experiments show this speeds up SIMD packs and speeds up vanilla YAKL on the CPU. GPU performance appears to be slightly faster with size_t, but only slightly, but at least no performance degradation on nvidia GPUs.