### PR TITLE
Return early from parallel_for with zero iterations

### DIFF
--- a/src/YAKL_parallel_for_common.h
+++ b/src/YAKL_parallel_for_common.h
@@ -498,6 +498,14 @@ inline void parallel_inner_cpu_serial( Bounds<N,simple> const &bounds , F const 
 template <class F, int N, bool simple, int VecLen=YAKL_DEFAULT_VECTOR_LEN , bool B4B=false>
 inline void parallel_for( char const * str , Bounds<N,simple> const &bounds , F const &f ,
                           LaunchConfig<VecLen,B4B> config = LaunchConfig<>() ) {
+  // exit early if there is no work to do
+  if (bounds.nIter == 0) {
+  #ifdef YAKL_VERBOSE
+    verbose_inform(std::string("Skipping launch of parallel_for labeled \"")+std::string(str)+std::string("\" with zero threads"),str);
+  #endif
+    return;
+  }
+
   #ifdef YAKL_VERBOSE
     verbose_inform(std::string("Launching parallel_for labeled \"")+std::string(str)+std::string("\" with ")+std::to_string(bounds.nIter)+" threads",str);
   #endif
@@ -587,6 +595,14 @@ inline void parallel_for( char const * str , LBnd bnd , F const &f ,
 template <class F, int N, bool simple, int VecLen=YAKL_DEFAULT_VECTOR_LEN, bool B4B=false>
 inline void parallel_outer( char const * str , Bounds<N,simple> const &bounds , F const &f ,
                             LaunchConfig<VecLen,B4B> config = LaunchConfig<>() ) {
+  // exit early if there is no work to do
+  if (bounds.nIter == 0) {
+  #ifdef YAKL_VERBOSE
+    verbose_inform(std::string("Skipping launch of parallel_outer labeled \"")+std::string(str)+std::string("\" with zero outer threads"),str);
+  #endif
+    return;
+  }
+
   #ifdef YAKL_VERBOSE
     verbose_inform(std::string("Launching parallel_outer labeled \"")+std::string(str)+std::string("\" with ")+std::to_string(bounds.nIter)+
                    std::string(" outer threads and ")+


### PR DESCRIPTION
Motivation: I noticed that if  `bounds.nIter == 0`  then here https://github.com/mrnorman/YAKL/blob/da305cf6866e4754e5ce73337dcd34a3909dd24f/src/YAKL_parallel_for_common.h#L75
`nIter` underflows since it is unsigned. This causes a launch of huge number of threads with no work. I think it makes sense to fix this issue by returning early from parallel_for with zero total iterations, avoiding any overhead.
