### PR TITLE
Fix build error in ArrayIR.h on MacOS

### DIFF
--- a/external/ArrayIR.h
+++ b/external/ArrayIR.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <array>
+
 /** @brief The ArrayIR namespace holds the ArrayIR class and memory type constants associated with ArrayIR.
            This class holds library-agnostic Array metadata to make it easy to transfer array objects between
            different C++ libraries. */


### PR DESCRIPTION
I was getting a lot error like this:
'YAKL/external/ArrayIR.h:38:28: error: implicit instantiation of undefined template 'std::array<unsigned long, 2>''