### PR TITLE
Use createHostObject instead of createHostCopy in io::read

### DIFF
--- a/src/extensions/YAKL_netcdf.h
+++ b/src/extensions/YAKL_netcdf.h
@@ -545,7 +545,7 @@ namespace yakl {
       } else { yakl_throw("Variable does not exist"); }
 
       if (myMem == memDevice) {
-        auto arrHost = arr.createHostCopy();
+        auto arrHost = arr.createHostObject();
         if (std::is_same<T,bool>::value) {
           Array<int,rank,memHost,myStyle> tmp("tmp",dimSizes);
           var.getVar(tmp.data());


### PR DESCRIPTION
This avoids an uninitialized access warning in compute-sanitizer.