### PR TITLE
Adjusting when mutex is held to improve performance on OpenMP backend

### DIFF
--- a/src/YAKL_ArrayBase.h
+++ b/src/YAKL_ArrayBase.h
@@ -12,8 +12,8 @@ namespace yakl {
 
   // This implements all functionality used by all dynamically allocated arrays
   /** @brief This class implements functionality common to both yakl::styleC and yakl::styleFortran `Array` objects.
-    * 
-    * @param T      Type of the array. For yakl::memHost array objects, this can generally be any type. For 
+    *
+    * @param T      Type of the array. For yakl::memHost array objects, this can generally be any type. For
     *               yakl::memDevice array objects, this needs to be a type without a constructor, preferrably
     *               an arithmetic type.
     * @param rank   The number of dimensions for this array object.
@@ -140,9 +140,9 @@ namespace yakl {
 
     // Deep copy this array's contents to another array that's on the host
     /** @brief [ASYNCHRONOUS] [DEEP_COPY] Copy this array's contents to a yakl::memHost array.
-      * 
+      *
       * Arrays must have the same type and total number
-      * of elements. No checking of rank, style, or dimensionality is performed. Both arrays must be allocated. 
+      * of elements. No checking of rank, style, or dimensionality is performed. Both arrays must be allocated.
       * `this` array may be in yakl::memHost or yakl::memDevice space. */
     template <int theirRank, int theirStyle>
     inline void deep_copy_to(Array<typename std::remove_cv<T>::type,theirRank,memHost,theirStyle> const &lhs , Stream stream = Stream()) const {
@@ -163,9 +163,9 @@ namespace yakl {
 
     // Deep copy this array's contents to another array that's on the device
     /** @brief [ASYNCHRONOUS] [DEEP_COPY] Copy this array's contents to a yakl::memDevice array.
-      * 
+      *
       * Arrays must have the same type and total number
-      * of elements. No checking of rank, style, or dimensionality is performed. Both arrays must be allocated. 
+      * of elements. No checking of rank, style, or dimensionality is performed. Both arrays must be allocated.
       * `this` array may be in yakl::memHost or yakl::memDevice space. */
     template <int theirRank, int theirStyle>
     inline void deep_copy_to(Array<typename std::remove_cv<T>::type,theirRank,memDevice,theirStyle> const &lhs , Stream stream = Stream()) const {
@@ -218,7 +218,7 @@ namespace yakl {
     /** @brief Set the object's string label (Host only) */
     void set_label(std::string label) { this->myname = label.c_str(); }
     /** @brief Returns how many array objects share this pointer if owned; or `0` if unowned.
-      * 
+      *
       * Returns the use count for this array object's data pointer. I.e., this is how many yakl::Array objects currently
       * share this data pointer. If this returns a value of `0`, that means that this array object is **not** being reference
       * counted, meaning it performed no allocation upon creation, will perform no deallocation upon destruction, and has
@@ -233,7 +233,7 @@ namespace yakl {
     /** @private */
     template <class TLOC=T, typename std::enable_if< ! std::is_const<TLOC>::value , int >::type = 0>
     inline void allocate() {
-      // static_assert( std::is_arithmetic<T>() || myMem == memHost , 
+      // static_assert( std::is_arithmetic<T>() || myMem == memHost ,
       //                "ERROR: You cannot use non-arithmetic types inside owned Arrays on the device" );
       yakl_mtx_lock();
       this->refCount = new int;
@@ -252,7 +252,7 @@ namespace yakl {
 
     // Decrement the reference counter (if owned), and if it's zero after decrement, then deallocate the data
     // For const types, the pointer must be const casted to a non-const type before deallocation
-    /** @brief If owned, decrement the reference counter; if ref counter reaches zero, deallocate memory; 
+    /** @brief If owned, decrement the reference counter; if ref counter reaches zero, deallocate memory;
       *        If non-owned, does nothing.
       *
       *        If the reference counter reaches zero, meaning no other array objects
@@ -261,10 +261,10 @@ namespace yakl {
       *        an empty array object. This is safe to call even if this array object is not yet allocated. */
     template <class TLOC=T, typename std::enable_if< std::is_const<TLOC>::value , int >::type = 0>
     inline void deallocate() {
-      yakl_mtx_lock();
       typedef typename std::remove_cv<T>::type T_non_const;
       T_non_const *data = const_cast<T_non_const *>(this->myData);
       if (this->refCount != nullptr) {
+        yakl_mtx_lock();
         (*(this->refCount))--;
 
         if (*this->refCount == 0) {
@@ -290,9 +290,8 @@ namespace yakl {
             this->myData = nullptr;
           }
         }
-
+        yakl_mtx_unlock();
       }
-      yakl_mtx_unlock();
     }
 
 
@@ -300,8 +299,8 @@ namespace yakl {
     /** @copydoc yakl::ArrayBase::deallocate() */
     template <class TLOC=T, typename std::enable_if< ! std::is_const<TLOC>::value , int >::type = 0>
     inline void deallocate() {
-      yakl_mtx_lock();
       if (this->refCount != nullptr) {
+        yakl_mtx_lock();
         (*(this->refCount))--;
 
         if (*this->refCount == 0) {
@@ -328,8 +327,8 @@ namespace yakl {
           }
         }
 
-      }
       yakl_mtx_unlock();
+      }
     }
 
 

--- a/src/YAKL_CArray.h
+++ b/src/YAKL_CArray.h
@@ -6,7 +6,7 @@ __YAKL_NAMESPACE_WRAPPER_BEGIN__
 namespace yakl {
 
   /** @brief This implements the yakl:Array class with yakl::styleC behavior
-    * 
+    *
     * C-style behavior means all lower bounds for
     * dimensions are zero, and index ordering is row-major, meaning the right-most index varies the fastest.
     * IMPORTANT: Please see the yakl::ArrayBase class because this class includes all of its functionality.
@@ -25,8 +25,8 @@ namespace yakl {
     * arr2 = 5; // This will change both arr1 and arr2 because they share the same data pointer
     * ```
     * This will share the same data pointer between `arr1` and `arr2`. Further, passing yakl::Array objects by value is fast
-    * because it only copies the metadata over and shares the pointer to the underlying data. 
-    * 
+    * because it only copies the metadata over and shares the pointer to the underlying data.
+    *
     * To copy data to another array object's data pointer, use `deep_copy_to()`, `createHostCopy()`, or `createDeviceCopy()`.
     * ```
     * yakl::Array<float,1,memHost,styleC> arr1("arr1",n);
@@ -62,7 +62,7 @@ namespace yakl {
     /** @brief This is the type `T` with `const` added to it
       * @details If the original type has `volatile`, then so will this type. */
     typedef typename std::add_const<type>::type    const_value_type;
-    /** @brief This is the type `T` with `const` removed from it 
+    /** @brief This is the type `T` with `const` removed from it
       * @details If the original type has `volatile`, then so will this type. */
     typedef typename std::remove_const<type>::type non_const_value_type;
 
@@ -97,7 +97,7 @@ namespace yakl {
       * Create and allocate an owned and reference counted array object.
       * For C-style array objects, the right-most index varies the fastest. Constructor must match
       * the rank template argument.
-      *        
+      *
       * @param label  String label for this array.
       * @param d[0-7] Size of the respective dimension.
       * @param dims   yakl::Dims object containing the dimensions sizes. Must match the array rank.
@@ -191,7 +191,7 @@ namespace yakl {
       for (int i=0; i < rank; i++) { this->dimension[i] = dims[i]; }
       YAKL_EXECUTE_ON_HOST_ONLY( this->allocate(); )
     }
-    
+
 
     // This exists to hold common documentation for all non-owned constructors.
     /** @class doxhide_CArray_non_owned_constructors
@@ -199,14 +199,14 @@ namespace yakl {
       *
       * This is one of the yakl::CArray "non-owned" constructors.
       * Create a non-owned and non-reference-counted array object that wraps the
-      * provided data pointer. 
+      * provided data pointer.
       * For C-style array objects, the right-most index varies the fastest. Constructor must match
       * the rank template argument.
       * When creating a non-owned array object using this form of constructor, it is up to the user to ensure
       * that the underlying data pointer remains allocationg while it is used by this array object.
       * Since this performs no allocations, this constructor may be called on the device, and it has very
       * little runtime cost associated with it.
-      *        
+      *
       * @param label  String label for this array.
       * @param data   Pointer to the allocated data being wrapped by this non-owned array object
       * @param d[0-7] Size of the respective dimension.
@@ -316,7 +316,7 @@ namespace yakl {
     }
     /** @brief Copy metadata, share data pointer; if owned, increment reference counter. No deep copy. */
     YAKL_INLINE Array(Array<const_value_type,rank,myMem,styleC> const &rhs) {
-      static_assert( std::is_const<T>::value , 
+      static_assert( std::is_const<T>::value ,
                      "ERROR: Cannot create non-const Array using const Array" );
       // constructor, so no need to deallocate
       nullify();
@@ -335,7 +335,7 @@ namespace yakl {
     }
     /** @brief Copy metadata, share data pointer; if owned, increment reference counter. No deep copy. */
     YAKL_INLINE Array & operator=(Array<const_value_type,rank,myMem,styleC> const &rhs) {
-      static_assert( std::is_const<T>::value , 
+      static_assert( std::is_const<T>::value ,
                      "ERROR: Cannot create non-const Array using const Array" );
       if constexpr (std::is_const<T>::value) {
         if (this == &rhs) { return *this; }
@@ -353,13 +353,15 @@ namespace yakl {
       }
       this->myname = rhs.myname;
       this->myData   = rhs.myData;
-      YAKL_EXECUTE_ON_HOST_ONLY( yakl_mtx_lock(); )
-      this->refCount = rhs.refCount;
-      if (this->refCount != nullptr) {
+      if (rhs.refCount != nullptr) {
+        YAKL_EXECUTE_ON_HOST_ONLY( yakl_mtx_lock(); )
+        this->refCount = rhs.refCount;
         // YAKL_EXECUTE_ON_HOST_ONLY( (*(this->refCount))++; )  // This gives an nvc++ error
-        YAKL_EXECUTE_ON_HOST_ONLY( { (*(this->refCount))++; } )  // This works around the nvc++ error
+        YAKL_EXECUTE_ON_HOST_ONLY( if (this->refCount) { (*(this->refCount))++; } )  // This works around the nvc++ error
+        YAKL_EXECUTE_ON_HOST_ONLY( yakl_mtx_unlock(); )
+      } else {
+        this->refCount = nullptr;
       }
-      YAKL_EXECUTE_ON_HOST_ONLY( yakl_mtx_unlock(); )
     }
 
 
@@ -404,7 +406,7 @@ namespace yakl {
 
     /*
     DESTRUCTOR
-    Decrement the refCounter, and if it's zero, deallocate and nullify.  
+    Decrement the refCounter, and if it's zero, deallocate and nullify.
     */
     /** @brief If owned, decrement reference counter, and deallocate data when it reaches zero. If non-owned, does nothing */
     YAKL_INLINE ~Array() {
@@ -443,7 +445,7 @@ namespace yakl {
     // Common detailed documentation for all indexers
     /** @class doxhide_CArray_indexers
       * @brief dummy
-      * 
+      *
       * Return a reference to the element at the requested index. Number of indices must match the number of dimensions
       * in this array, `N`. The array object must already be allocated. For index checking, please define the `YAKL_DEBUG`
       * CPP macro. Use zero-based indexing with the right-most value varying the fastest (row-major ordering).
@@ -664,7 +666,7 @@ namespace yakl {
       * array object is owned and reference counted, guaranteeing the underling data remains valid while the returned
       * slice is used. If slicing is performed on the device, a non-owned array object is returned, though this
       * rarely if ever presents an issue on the device.
-      * 
+      *
       * Example usage:
       * ```
       * auto myslice = arr.slice<2>({k,COLON,COLON});
@@ -673,10 +675,10 @@ namespace yakl {
       * @param dims yakl::Dims object specifying the indices at which the slice should occur as well as the dimensions
       *        that should be sliced.
       * @param i[0-7]: Index of the array slice.
-      * 
+      *
       */
 
-    /** @brief Array slice using initializer list or std::vector indices 
+    /** @brief Array slice using initializer list or std::vector indices
       * \copydetails doxhide_CArray_slicing */
     template <int N> YAKL_INLINE Array<T,N,myMem,styleC> slice( Dims const &dims ) const {
       #ifdef YAKL_DEBUG
@@ -708,58 +710,60 @@ namespace yakl {
       }
       ret.myData = &(this->myData[retOff]);
       YAKL_EXECUTE_ON_HOST_ONLY(
-        yakl_mtx_lock();
-        ret.refCount = this->refCount;
         if (this->refCount != nullptr) {
-          (*(this->refCount))++;
+          yakl_mtx_lock();
+          ret.refCount = this->refCount;
+          if (this->refCount != nullptr) {
+            (*(this->refCount))++;
+          }
+          yakl_mtx_unlock();
         }
-        yakl_mtx_unlock();
       )
       return ret;
     }
-    /** @brief Array slice of 1-D array 
+    /** @brief Array slice of 1-D array
       * \copydetails doxhide_CArray_slicing */
     template <int N> YAKL_INLINE Array<T,N,myMem,styleC> slice( int i0 ) const {
       static_assert( rank == 1 , "ERROR: Calling slice() with 1 index on a non-rank-1 array" );
       static_assert( N <= rank , "ERROR: Calling slice() with more dimenions than this array's rank" );
       return slice<N>( Dims(i0) );
     }
-    /** @brief Array slice of 2-D array 
+    /** @brief Array slice of 2-D array
       * \copydetails doxhide_CArray_slicing */
     template <int N> YAKL_INLINE Array<T,N,myMem,styleC> slice( int i0, int i1 ) const {
       static_assert( rank == 2 , "ERROR: Calling slice() with 2 index on a non-rank-2 array" );
       static_assert( N <= rank , "ERROR: Calling slice() with more dimenions than this array's rank" );
       return slice<N>( Dims(i0,i1) );
     }
-    /** @brief Array slice of 3-D array 
+    /** @brief Array slice of 3-D array
       * \copydetails doxhide_CArray_slicing */
     template <int N> YAKL_INLINE Array<T,N,myMem,styleC> slice( int i0, int i1, int i2 ) const {
       static_assert( rank == 3 , "ERROR: Calling slice() with 3 index on a non-rank-3 array" );
       static_assert( N <= rank , "ERROR: Calling slice() with more dimenions than this array's rank" );
       return slice<N>( Dims(i0,i1,i2) );
     }
-    /** @brief Array slice of 4-D array 
+    /** @brief Array slice of 4-D array
       * \copydetails doxhide_CArray_slicing */
     template <int N> YAKL_INLINE Array<T,N,myMem,styleC> slice( int i0, int i1, int i2, int i3 ) const {
       static_assert( rank == 4 , "ERROR: Calling slice() with 4 index on a non-rank-4 array" );
       static_assert( N <= rank , "ERROR: Calling slice() with more dimenions than this array's rank" );
       return slice<N>( Dims(i0,i1,i2,i3) );
     }
-    /** @brief Array slice of 5-D array 
+    /** @brief Array slice of 5-D array
       * \copydetails doxhide_CArray_slicing */
     template <int N> YAKL_INLINE Array<T,N,myMem,styleC> slice( int i0, int i1, int i2, int i3, int i4 ) const {
       static_assert( rank == 5 , "ERROR: Calling slice() with 5 index on a non-rank-5 array" );
       static_assert( N <= rank , "ERROR: Calling slice() with more dimenions than this array's rank" );
       return slice<N>( Dims(i0,i1,i2,i3,i4) );
     }
-    /** @brief Array slice of 6-D array 
+    /** @brief Array slice of 6-D array
       * \copydetails doxhide_CArray_slicing */
     template <int N> YAKL_INLINE Array<T,N,myMem,styleC> slice( int i0, int i1, int i2, int i3, int i4, int i5 ) const {
       static_assert( rank == 6 , "ERROR: Calling slice() with 6 index on a non-rank-6 array" );
       static_assert( N <= rank , "ERROR: Calling slice() with more dimenions than this array's rank" );
       return slice<N>( Dims(i0,i1,i2,i3,i4,i5) );
     }
-    /** @brief Array slice of 7-D array 
+    /** @brief Array slice of 7-D array
       * \copydetails doxhide_CArray_slicing */
     template <int N> YAKL_INLINE Array<T,N,myMem,styleC> slice( int i0, int i1, int i2, int i3, int i4, int i5,
                                                                 int i6 ) const {
@@ -767,7 +771,7 @@ namespace yakl {
       static_assert( N <= rank , "ERROR: Calling slice() with more dimenions than this array's rank" );
       return slice<N>( Dims(i0,i1,i2,i3,i4,i5,i6) );
     }
-    /** @brief Array slice of 8-D array 
+    /** @brief Array slice of 8-D array
       * \copydetails doxhide_CArray_slicing */
     template <int N> YAKL_INLINE Array<T,N,myMem,styleC> slice( int i0, int i1, int i2, int i3, int i4, int i5, int i6,
                                                                 int i7 ) const {
@@ -788,7 +792,7 @@ namespace yakl {
       * counter is incremented. This means you're guaranteed the data pointer is valid throughout the use
       * of the returned array object. If this is performed on the device, then the returned array is non-owned.
       * Be careful doing this in the innermost loop, even on the host, though, because it is still copying
-      * array metadata, and you may notice the extra cost. 
+      * array metadata, and you may notice the extra cost.
       *
       * Example usage:
       * ```
@@ -798,7 +802,7 @@ namespace yakl {
       * ```
       * @param dims   yakl::Dims object containing the dimensions of the new array object that shares this object's data pointer
       * @param i[0-7] dimensions of the newly reshaped array
-      * 
+      *
       */
 
     /** @brief Reshape array using initializer list or std::vector indices
@@ -818,12 +822,14 @@ namespace yakl {
       ret.myname = this->myname;
       ret.myData = this->myData;
       YAKL_EXECUTE_ON_HOST_ONLY(
-        yakl_mtx_lock();
-        ret.refCount = this->refCount;
         if (this->refCount != nullptr) {
-          (*(this->refCount))++;
+          yakl_mtx_lock();
+          ret.refCount = this->refCount;
+          if (this->refCount != nullptr) {
+            (*(this->refCount))++;
+          }
+          yakl_mtx_unlock();
         }
-        yakl_mtx_unlock();
       )
       return ret;
     }
@@ -854,15 +860,15 @@ namespace yakl {
 
 
     /** @brief Collapse this array into a 1-D array
-      * 
+      *
       * Returns an array object that shares the data pointer of this array object but has only one dimension,
-      * with all of this array object's dimensions collapsed into a single dimension. 
+      * with all of this array object's dimensions collapsed into a single dimension.
       * This is a fast operation. No allocations are performed, and no underlying data is allocated.
       * If this is performed on the host, then the returned array is owned, and the data pointer's reference
       * counter is incremented. This means you're guaranteed the data pointer is valid throughout the use
       * of the returned array object. If this is performed on the device, then the returned array is non-owned.
       * Be careful doing this in the innermost loop, even on the host, though, because it is still copying
-      * array metadata, and you may notice the extra cost. 
+      * array metadata, and you may notice the extra cost.
       * Example usage: `auto new_arr_1d = arr.collapse();`
       */
     YAKL_INLINE Array<T,1,myMem,styleC> collapse() const {
@@ -874,12 +880,14 @@ namespace yakl {
       ret.myname = this->myname;
       ret.myData = this->myData;
       YAKL_EXECUTE_ON_HOST_ONLY(
-        yakl_mtx_lock();
-        ret.refCount = this->refCount;
         if (this->refCount != nullptr) {
-          (*(this->refCount))++;
+          yakl_mtx_lock();
+          ret.refCount = this->refCount;
+          if (this->refCount != nullptr) {
+            (*(this->refCount))++;
+          }
+          yakl_mtx_unlock();
         }
-        yakl_mtx_unlock();
       )
       return ret;
     }
@@ -888,13 +896,13 @@ namespace yakl {
     // Create a host copy of this array. Even if the array exists on the host, a deep copy to a separate
     // object is still performed to avoid any potential bugs when the user expects this behavior
     /** @brief [DEEP_COPY] Create a copy of this array in yakl::memHost space
-      * 
+      *
       * Create and allocate a yakl::memHost array object of the same type, rank, dimensions, and style. Then deep copy
       * the data from this array object to the array object returned by this function. This is a slow routine.
       * It both allocates and deep copies the underlying data.
-      * 
+      *
       * Even if the current array is yakl::memHost, this will still allocate and copy to a new object.
-      * 
+      *
       * @returns A newly allocated array of the same type, rank, and style as this one in yakl::memHost space with
       *          data copied from this array object.
       */
@@ -912,7 +920,7 @@ namespace yakl {
 
     // Create a separately allocate host object with the same rank, memory space, and style
     /** @brief Create and allocate a yakl::memHost array object of the same type, rank, dimensions, and style.
-      * 
+      *
       * This is the same as createHostCopy() but without the data deep copy portion.
       * This may be slow since host objects do not use the YAKL pool allocator.
       * NOTE: This does not deep copy data. It merely creates and allocates a new array object and returns it.
@@ -941,9 +949,9 @@ namespace yakl {
       * Create and allocate a yakl::memDevice array object of the same type, rank, dimensions, and style. Then deep copy
       * the data from this array object to the array object returned by this function. This is a slow routine.
       * It both allocates and deep copies the underlying data.
-      * 
+      *
       * Even if the current array is yakl::memDevice, this will still allocate and copy to a new object.
-      * 
+      *
       * @returns A newly allocated array of the same type, rank, and style as this one in yakl::memDevice space with
       *          data copied from this array object.
       */
@@ -985,7 +993,7 @@ namespace yakl {
 
     /* ACCESSORS */
     /** @brief Returns the dimensions of this array as a yakl::SArray object.
-      * 
+      *
       * You should use zero-based indexing on the returned SArray object. */
     YAKL_INLINE SArray<index_t,1,rank> get_dimensions() const {
       SArray<index_t,1,rank> ret;
@@ -993,7 +1001,7 @@ namespace yakl {
       return ret;
     }
     /** @brief Returns the lower bound of each dimension of this array (which are always all zero) as a yakl::SArray object.
-      * 
+      *
       * You should use zero-based indexing on the returned yakl::SArray object. */
     YAKL_INLINE SArray<index_t,1,rank> get_lbounds() const {
       SArray<index_t,1,rank> ret;
@@ -1001,7 +1009,7 @@ namespace yakl {
       return ret;
     }
     /** @brief Returns the upper bound of each dimension of this array as a yakl::SArray object.
-      * 
+      *
       * You should use zero-based indexing on the returned yakl::SArray object. */
     YAKL_INLINE SArray<index_t,1,rank> get_ubounds() const {
       SArray<index_t,1,rank> ret;

--- a/src/YAKL_CArray.h
+++ b/src/YAKL_CArray.h
@@ -354,6 +354,9 @@ namespace yakl {
       this->myname = rhs.myname;
       this->myData   = rhs.myData;
       if (rhs.refCount != nullptr) {
+        #ifdef YAKL_VERBOSE
+          verbose_inform("Copying owned array (holds mutex)", this->label());
+        #endif
         YAKL_EXECUTE_ON_HOST_ONLY( yakl_mtx_lock(); )
         this->refCount = rhs.refCount;
         // YAKL_EXECUTE_ON_HOST_ONLY( (*(this->refCount))++; )  // This gives an nvc++ error
@@ -711,6 +714,9 @@ namespace yakl {
       ret.myData = &(this->myData[retOff]);
       YAKL_EXECUTE_ON_HOST_ONLY(
         if (this->refCount != nullptr) {
+          #ifdef YAKL_VERBOSE
+            verbose_inform("Slicing owned array (holds mutex)", this->label());
+          #endif
           yakl_mtx_lock();
           ret.refCount = this->refCount;
           if (this->refCount != nullptr) {
@@ -823,6 +829,9 @@ namespace yakl {
       ret.myData = this->myData;
       YAKL_EXECUTE_ON_HOST_ONLY(
         if (this->refCount != nullptr) {
+          #ifdef YAKL_VERBOSE
+            verbose_inform("Reshaping owned array (holds mutex)", this->label());
+          #endif
           yakl_mtx_lock();
           ret.refCount = this->refCount;
           if (this->refCount != nullptr) {
@@ -881,6 +890,9 @@ namespace yakl {
       ret.myData = this->myData;
       YAKL_EXECUTE_ON_HOST_ONLY(
         if (this->refCount != nullptr) {
+          #ifdef YAKL_VERBOSE
+            verbose_inform("Collapsing owned array (holds mutex)", this->label());
+          #endif
           yakl_mtx_lock();
           ret.refCount = this->refCount;
           if (this->refCount != nullptr) {

--- a/src/YAKL_FArray.h
+++ b/src/YAKL_FArray.h
@@ -357,6 +357,9 @@ namespace yakl {
       this->myname = rhs.myname;
       this->myData   = rhs.myData;
       if (rhs.refCount != nullptr) {
+        #ifdef YAKL_VERBOSE
+          verbose_inform("Copying owned array (holds mutex)", this->label());
+        #endif
         YAKL_EXECUTE_ON_HOST_ONLY( yakl_mtx_lock(); )
         this->refCount = rhs.refCount;
         // YAKL_EXECUTE_ON_HOST_ONLY( (*(this->refCount))++; )  // This gives an nvc++ error
@@ -727,6 +730,9 @@ namespace yakl {
       ret.myData = &(this->myData[retOff]);
       YAKL_EXECUTE_ON_HOST_ONLY(
         if (this->refCount != nullptr) {
+          #ifdef YAKL_VERBOSE
+            verbose_inform("Slicing owned array (holds mutex)", this->label());
+          #endif
           yakl_mtx_lock();
           ret.refCount = this->refCount;
           if (this->refCount != nullptr) {
@@ -841,6 +847,9 @@ namespace yakl {
       ret.myData = this->myData;
       YAKL_EXECUTE_ON_HOST_ONLY(
         if (this->refCount != nullptr) {
+          #ifdef YAKL_VERBOSE
+            verbose_inform("Reshaping owned array (holds mutex)", this->label());
+          #endif
           yakl_mtx_lock();
           ret.refCount = this->refCount;
           if (this->refCount != nullptr) {
@@ -899,6 +908,9 @@ namespace yakl {
       ret.myData = this->myData;
       YAKL_EXECUTE_ON_HOST_ONLY(
         if (this->refCount != nullptr) {
+          #ifdef YAKL_VERBOSE
+            verbose_inform("Collapsing owned array (holds mutex)", this->label());
+          #endif
           yakl_mtx_lock();
           ret.refCount = this->refCount;
           if (this->refCount != nullptr) {


### PR DESCRIPTION
Should close #162. I've modified when the YAKL Array takes the mutex to be only when the reference count pointer isn't null. This makes temporary unowned views much cheaper on the OpenMP backend where host code still runs. To guarantee the same behaviour as before this requires a double check for nullptr in some places. This could be relaxed by bringing in some atomics, but this was the minimal check. 

I have also added warnings to `YAKL_VERBOSE` on doing other apparently cheap operations that grab the mutex (e.g. reshaping/collapsing/copy-constructing). 
In my case, a deep function was taking an array by value instead of reference, triggering the copy constructor and destroying performance. With verbose this would now output enough information to easily track that down.

@mrnorman If you would rather, I could put these verbose prints behind `YAKL_ARCH_OPENMP` to limit noise when running on other backends.